### PR TITLE
bug: 支持质量红线的插件指标，提示信息无法置空 #8355

### DIFF
--- a/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/dao/v2/QualityIndicatorDao.kt
+++ b/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/dao/v2/QualityIndicatorDao.kt
@@ -213,7 +213,7 @@ class QualityIndicatorDao {
                 if (enable != null) update.set(ENABLE, enable)
                 if (type != null) update.set(TYPE, type.toString())
                 if (!tag.isNullOrBlank()) update.set(TAG, tag)
-                if (!logPrompt.isNullOrBlank()) update.set(LOG_PROMPT, logPrompt)
+                if (!logPrompt.isNullOrBlank()) update.set(LOG_PROMPT, logPrompt) else update.set(LOG_PROMPT, "")
             }
             update.set(UPDATE_TIME, LocalDateTime.now())
                 .set(UPDATE_USER, userId)


### PR DESCRIPTION
bug: 支持质量红线的插件指标，提示信息无法置空 #8355