### PR TITLE
 feat: 制品库无法归档的第三方构建机日志支持保留至指定目录 TencentBlueKing#8391

### DIFF
--- a/src/backend/ci/core/common/common-service/src/main/kotlin/com/tencent/devops/common/service/utils/ZipUtil.kt
+++ b/src/backend/ci/core/common/common-service/src/main/kotlin/com/tencent/devops/common/service/utils/ZipUtil.kt
@@ -75,7 +75,7 @@ object ZipUtil {
         }
     }
 
-    fun zipDir(srcDir: File, zipFile: String) {
+    fun zipDir(srcDir: File, zipFile: String): File {
         FileOutputStream(zipFile).use { fileOutputStream ->
             BufferedOutputStream(fileOutputStream).use { bufferedOutputStream ->
                 ZipOutputStream(bufferedOutputStream).use { zipOutputStream ->
@@ -83,6 +83,7 @@ object ZipUtil {
                 }
             }
         }
+        return File(zipFile)
     }
 
     private fun handleZipOutputStream(srcDir: File, zipOutputStream: ZipOutputStream) {
@@ -103,6 +104,10 @@ object ZipUtil {
     @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     private fun zipFiles(zipOut: ZipOutputStream, sourceFile: File, parentDirPath: String) {
         val buf = ByteArray(2048)
+        if (sourceFile.isFile) {
+            zipFile(zipOut, sourceFile, sourceFile.name, buf)
+            return
+        }
         for (file in sourceFile.listFiles()) {
             val basePath = if (parentDirPath.isBlank()) {
                 file.name

--- a/src/backend/ci/core/log/api-log/src/main/kotlin/com/tencent/devops/common/log/pojo/TaskBuildLogProperty.kt
+++ b/src/backend/ci/core/log/api-log/src/main/kotlin/com/tencent/devops/common/log/pojo/TaskBuildLogProperty.kt
@@ -36,6 +36,8 @@ data class TaskBuildLogProperty(
     val elementId: String,
     @ApiModelProperty("日志文件子路径", required = true)
     val childPath: String,
+    @ApiModelProperty("日志zip文件子路径", required = true)
+    val childZipPath: String,
     @ApiModelProperty("日志文件句柄", required = true)
     val logFile: File,
     @ApiModelProperty("日志的存储模式", required = false)

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
@@ -356,6 +356,14 @@ object LoggerService {
 
                 val zipLog = ZipUtil.zipDir(property.logFile, property.logFile.absolutePath + ".zip")
                 zipLog.deleteOnExit()
+                // 如果日志文件过大，则取消归档
+                if (zipLog.length() > LOG_FILE_LENGTH_LIMIT) {
+                    logger.warn(
+                        "Cancel archiving task[$elementId] build log " +
+                            "file(${property.logFile.absolutePath}), length(${property.logFile.length()})"
+                    )
+                    return@forEach
+                }
                 // 开始归档符合归档条件的日志文件
                 logger.info("Archive task[$elementId] build log file(${property.logFile.absolutePath})")
                 try {

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
@@ -355,7 +355,6 @@ object LoggerService {
                 }
 
                 val zipLog = ZipUtil.zipDir(property.logFile, property.logFile.absolutePath + ".zip")
-                zipLog.deleteOnExit()
                 // 如果日志文件过大，则取消归档
                 if (zipLog.length() > LOG_FILE_LENGTH_LIMIT) {
                     logger.warn(

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/logger/LoggerService.kt
@@ -32,6 +32,8 @@ import com.tencent.devops.common.log.pojo.enums.LogStorageMode
 import com.tencent.devops.common.log.pojo.enums.LogType
 import com.tencent.devops.common.log.pojo.message.LogMessage
 import com.tencent.devops.common.service.utils.CommonUtils
+import com.tencent.devops.common.service.utils.ZipUtil
+import com.tencent.devops.common.util.HttpRetryUtils
 import com.tencent.devops.log.meta.Ansi
 import com.tencent.devops.process.pojo.BuildVariables
 import com.tencent.devops.process.utils.PIPELINE_START_USER_ID
@@ -49,10 +51,9 @@ import com.tencent.devops.worker.common.api.archive.pojo.TokenType
 import com.tencent.devops.worker.common.api.log.LogSDKApi
 import com.tencent.devops.worker.common.env.AgentEnv
 import com.tencent.devops.worker.common.service.RepoServiceFactory
+import com.tencent.devops.worker.common.service.SensitiveValueService
 import com.tencent.devops.worker.common.utils.ArchiveUtils
 import com.tencent.devops.worker.common.utils.FileUtils
-import com.tencent.devops.common.util.HttpRetryUtils
-import com.tencent.devops.worker.common.service.SensitiveValueService
 import com.tencent.devops.worker.common.utils.WorkspaceUtils
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -345,15 +346,6 @@ object LoggerService {
                 // 如果不是LOCAL状态直接跳过
                 if (property.logStorageMode != LogStorageMode.LOCAL) return@forEach
 
-                // 如果日志文件过大，则取消归档
-                if (property.logFile.length() > LOG_FILE_LENGTH_LIMIT) {
-                    logger.warn(
-                        "Cancel archiving task[$elementId] build log " +
-                            "file(${property.logFile.absolutePath}), length(${property.logFile.length()})"
-                    )
-                    return@forEach
-                }
-
                 if (!property.logFile.exists()) {
                     logger.warn(
                         "Cancel archiving task[$elementId] build log " +
@@ -362,6 +354,8 @@ object LoggerService {
                     return@forEach
                 }
 
+                val zipLog = ZipUtil.zipDir(property.logFile, property.logFile.absolutePath + ".zip")
+                zipLog.deleteOnExit()
                 // 开始归档符合归档条件的日志文件
                 logger.info("Archive task[$elementId] build log file(${property.logFile.absolutePath})")
                 try {
@@ -370,8 +364,8 @@ object LoggerService {
                         retryPeriodMills = 1000
                     ) {
                         ArchiveUtils.archiveLogFile(
-                            file = property.logFile,
-                            destFullPath = property.childPath,
+                            file = zipLog,
+                            destFullPath = property.childZipPath,
                             buildVariables = buildVariables!!,
                             token = token
                         )

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/WorkspaceUtils.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/WorkspaceUtils.kt
@@ -146,7 +146,13 @@ object WorkspaceUtils {
         val logFile = File(pipelineLogDir, childPath)
         logFile.parentFile.mkdirs()
         logFile.createNewFile()
-        return TaskBuildLogProperty(elementId, childPath, logFile, logStorageMode)
+        return TaskBuildLogProperty(
+            elementId = elementId,
+            childPath = childPath,
+            childZipPath = "$childPath.zip",
+            logFile = logFile,
+            logStorageMode = logStorageMode
+        )
     }
 
     private fun getBuildLogChildPath(


### PR DESCRIPTION
①原先 >100w行并且>1GB的日志是无法归档的，于是选择压缩之后再归档。
②日志下载处，兼容存量归档日志，先查.zip，查不到再查.log