### PR TITLE
bug: 流水线中配有两个相同的codecc任务时，保存指标数据偶现死锁 #8008

### DIFF
--- a/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/cron/QualityDailyReportJob.kt
+++ b/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/cron/QualityDailyReportJob.kt
@@ -33,7 +33,6 @@ import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.service.utils.CommonUtils
 import com.tencent.devops.quality.config.QualityDailyDispatch
 import com.tencent.devops.quality.dao.HistoryDao
-import com.tencent.devops.quality.service.v2.QualityHisMetadataService
 import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/cron/QualityDailyReportJob.kt
+++ b/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/cron/QualityDailyReportJob.kt
@@ -28,9 +28,12 @@
 package com.tencent.devops.quality.cron
 
 import com.tencent.devops.common.event.pojo.measure.QualityReportEvent
+import com.tencent.devops.common.redis.RedisLock
+import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.service.utils.CommonUtils
 import com.tencent.devops.quality.config.QualityDailyDispatch
 import com.tencent.devops.quality.dao.HistoryDao
+import com.tencent.devops.quality.service.v2.QualityHisMetadataService
 import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,7 +47,8 @@ import java.time.format.DateTimeFormatter
 class QualityDailyReportJob @Autowired constructor(
     private val historyDao: HistoryDao,
     private val qualityDailyDispatch: QualityDailyDispatch,
-    private val dslContext: DSLContext
+    private val dslContext: DSLContext,
+    private val redisOperation: RedisOperation
 ) {
 
     private val logger = LoggerFactory.getLogger(QualityDailyReportJob::class.java)
@@ -62,35 +66,45 @@ class QualityDailyReportJob @Autowired constructor(
             return
         }
 
-        if (!clusterName.split(",").contains(CommonUtils.getDbClusterName())) {
-            return
-        } else {
-            val startTime = LocalDateTime.now().minusDays(1)
-            val endTime = LocalDateTime.now()
-            val result = historyDao.batchDailyTotalCount(
-                dslContext = dslContext,
-                startTime = startTime,
-                endTime = endTime
-            )
-            result.forEach {
-                val interceptCount = historyDao.countIntercept(
+        val redisLock = RedisLock(redisOperation, "QUALITY_DAILY_REPORT", 3600L)
+        try {
+            if (!redisLock.tryLock()) {
+                logger.info("get QUALITY_DAILY_REPORT lock failed, skip.")
+                return
+            }
+
+            if (!clusterName.split(",").contains(CommonUtils.getDbClusterName())) {
+                return
+            } else {
+                val startTime = LocalDateTime.now().minusDays(1)
+                val endTime = LocalDateTime.now()
+                val result = historyDao.batchDailyTotalCount(
                     dslContext = dslContext,
-                    projectId = it.value1(),
-                    pipelineId = null,
-                    ruleId = null,
                     startTime = startTime,
                     endTime = endTime
                 )
-                qualityDailyDispatch.dispatch(
-                    QualityReportEvent(
-                        statisticsTime = startTime.format(DateTimeFormatter.ISO_DATE),
+                result.forEach {
+                    val interceptCount = historyDao.countIntercept(
+                        dslContext = dslContext,
                         projectId = it.value1(),
-                        interceptedCount = interceptCount.toInt(),
-                        totalCount = it.value2()
+                        pipelineId = null,
+                        ruleId = null,
+                        startTime = startTime,
+                        endTime = endTime
                     )
-                )
+                    qualityDailyDispatch.dispatch(
+                        QualityReportEvent(
+                            statisticsTime = startTime.format(DateTimeFormatter.ISO_DATE),
+                            projectId = it.value1(),
+                            interceptedCount = interceptCount.toInt(),
+                            totalCount = it.value2()
+                        )
+                    )
+                }
+                logger.info("finish to send quality daily data.")
             }
-            logger.info("finish to send quality daily data.")
+        } finally {
+            redisLock.unlock()
         }
     }
 }


### PR DESCRIPTION
bug: 流水线中配有两个相同的codecc任务时，保存指标数据偶现死锁