### PR TITLE
bug: 流水线启动接口性能优化 #8615 

### DIFF
--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/constant/StringConstant.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/constant/StringConstant.kt
@@ -1,0 +1,4 @@
+package com.tencent.devops.common.api.constant
+
+fun String.coerceAtMaxLength(maxLength: Int): String =
+    if (this.length > maxLength) this.substring(0, maxLength) else this

--- a/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/constant/StringConstantKtTest.kt
+++ b/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/constant/StringConstantKtTest.kt
@@ -1,8 +1,7 @@
 package com.tencent.devops.common.api.constant
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.Assertions.*
 
 class StringConstantKtTest {
 

--- a/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/constant/StringConstantKtTest.kt
+++ b/src/backend/ci/core/common/common-api/src/test/kotlin/com/tencent/devops/common/api/constant/StringConstantKtTest.kt
@@ -1,0 +1,17 @@
+package com.tencent.devops.common.api.constant
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+class StringConstantKtTest {
+
+    @Test
+    fun coerceAtMaxLength() {
+        val expect = "12345678"
+        val s10 = "1234567890"
+        assertEquals(expect, s10.coerceAtMaxLength(expect.length))
+        assertEquals(s10, s10.coerceAtMaxLength(s10.length))
+        assertEquals(s10, s10.coerceAtMaxLength(s10.length + 100))
+    }
+}

--- a/src/backend/ci/core/common/common-db-base/src/main/kotlin/com/tencent/devops/common/db/listener/BkJooqExecuteListener.kt
+++ b/src/backend/ci/core/common/common-db-base/src/main/kotlin/com/tencent/devops/common/db/listener/BkJooqExecuteListener.kt
@@ -4,10 +4,12 @@ import org.jooq.ExecuteContext
 import org.jooq.impl.DefaultExecuteListener
 import org.jooq.tools.StopWatch
 import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 class BkJooqExecuteListener : DefaultExecuteListener() {
 
     companion object {
+        val thresholdNanos = TimeUnit.SECONDS.toNanos(1)
         private val logger = LoggerFactory.getLogger(BkJooqExecuteListener::class.java)
     }
 
@@ -19,10 +21,11 @@ class BkJooqExecuteListener : DefaultExecuteListener() {
     override fun executeEnd(ctx: ExecuteContext) {
         super.executeEnd(ctx)
         val stopWatch = ctx.data(getStopWatchName()) as StopWatch
-        val costTime = stopWatch.split() / 1000000 // 单位：毫秒
-        if (costTime > 1000) {
+        val costTime = stopWatch.split()
+        if (costTime > thresholdNanos) {
             // sql执行超时打印告警日志
-            logger.warn("Bk Slow SQL:[${ctx.query()}] cost $costTime ms")
+            val sql = ctx.query().toString().replace(Regex("[\r\n]"), " ")
+            logger.warn("Bk Slow SQL cost ${TimeUnit.NANOSECONDS.toMillis(costTime)} ms. SQL:[$sql]")
         }
     }
 

--- a/src/backend/ci/core/common/common-db-base/src/main/kotlin/com/tencent/devops/common/db/utils/JooqUtils.kt
+++ b/src/backend/ci/core/common/common-db-base/src/main/kotlin/com/tencent/devops/common/db/utils/JooqUtils.kt
@@ -25,8 +25,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.tencent.devops.common.service.utils
+package com.tencent.devops.common.db.utils
 
+import com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException
 import org.jooq.DatePart
 import org.jooq.Field
 import org.jooq.exception.DataAccessException
@@ -46,7 +47,8 @@ object JooqUtils {
         }
     }
 
-    private fun DataAccessException.isDeadLock(): Boolean = message?.contains(JooqDeadLockMessage) == true
+    private fun DataAccessException.isDeadLock(): Boolean =
+        message?.contains(JooqDeadLockMessage) == true || this.cause is MySQLTransactionRollbackException
 
     fun timestampDiff(part: DatePart, t1: Field<Timestamp>, t2: Field<Timestamp>): Field<Long> {
         return DSL.field(

--- a/src/backend/ci/core/common/common-db-base/src/test/kotlin/com/tencent/devops/common/db/utils/JooqUtilsTest.kt
+++ b/src/backend/ci/core/common/common-db-base/src/test/kotlin/com/tencent/devops/common/db/utils/JooqUtilsTest.kt
@@ -1,4 +1,4 @@
-package com.tencent.devops.common.service.utils
+package com.tencent.devops.common.db.utils
 
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Assertions

--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/enums/StartType.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/enums/StartType.kt
@@ -28,6 +28,15 @@
 package com.tencent.devops.common.pipeline.enums
 
 import com.tencent.devops.common.api.pojo.IdValue
+import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGitWebHookTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGithubWebHookTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGitlabWebHookTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeSVNWebHookTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeTGitWebHookTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.ManualTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.RemoteTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.TimerTriggerElement
+import com.tencent.devops.common.pipeline.pojo.element.trigger.enums.CodeType
 import org.slf4j.LoggerFactory
 
 enum class StartType {
@@ -81,6 +90,27 @@ enum class StartType {
             }
 
             return result
+        }
+
+        fun transform(startType: String, webhookType: String?): String {
+            return when (startType) {
+                MANUAL.name -> ManualTriggerElement.classType
+                TIME_TRIGGER.name -> TimerTriggerElement.classType
+                WEB_HOOK.name -> {
+                    when (webhookType) {
+                        CodeType.SVN.name -> CodeSVNWebHookTriggerElement.classType
+                        CodeType.GIT.name -> CodeGitWebHookTriggerElement.classType
+                        CodeType.GITLAB.name -> CodeGitlabWebHookTriggerElement.classType
+                        CodeType.GITHUB.name -> CodeGithubWebHookTriggerElement.classType
+                        CodeType.TGIT.name -> CodeTGitWebHookTriggerElement.classType
+                        else -> RemoteTriggerElement.classType
+                    }
+                }
+
+                else -> { // SERVICE.name,  PIPELINE.name, REMOTE.name
+                    RemoteTriggerElement.classType
+                }
+            }
         }
     }
 }

--- a/src/backend/ci/core/common/common-redis/src/main/kotlin/com/tencent/devops/common/redis/RedisLock.kt
+++ b/src/backend/ci/core/common/common-redis/src/main/kotlin/com/tencent/devops/common/redis/RedisLock.kt
@@ -38,7 +38,8 @@ import java.util.UUID
 open class RedisLock(
     private val redisOperation: RedisOperation,
     private val lockKey: String,
-    private val expiredTimeInSeconds: Long
+    private val expiredTimeInSeconds: Long,
+    private val sleepTime: Long = 100L // 临时抽sleepTime出来，供特殊场景设置减少等待时间，后续用RedissionRedLock取代这个类
 ) : AutoCloseable {
     companion object {
         /**
@@ -80,7 +81,7 @@ open class RedisLock(
                 locked = true
                 return
             }
-            Thread.sleep(100)
+            Thread.sleep(sleepTime)
         }
     }
 

--- a/src/backend/ci/core/common/common-redis/src/main/kotlin/com/tencent/devops/common/redis/RedisOperation.kt
+++ b/src/backend/ci/core/common/common-redis/src/main/kotlin/com/tencent/devops/common/redis/RedisOperation.kt
@@ -145,9 +145,8 @@ class RedisOperation(private val redisTemplate: RedisTemplate<String, String>, p
         redisTemplate.opsForHash<String, String>().putAll(getFinalKey(key, isDistinguishCluster), map)
     }
 
-    fun hIncrBy(key: String, hashKey: String, delta: Long, isDistinguishCluster: Boolean? = false) {
+    fun hIncrBy(key: String, hashKey: String, delta: Long, isDistinguishCluster: Boolean? = false): Long =
         redisTemplate.opsForHash<String, String>().increment(getFinalKey(key, isDistinguishCluster), hashKey, delta)
-    }
 
     fun hget(key: String, hashKey: String, isDistinguishCluster: Boolean? = false): String? {
         return redisTemplate.opsForHash<String, String>().get(getFinalKey(key, isDistinguishCluster), hashKey)

--- a/src/backend/ci/core/common/common-service/src/test/kotlin/com/tencent/devops/common/service/utils/JooqUtilsTest.kt
+++ b/src/backend/ci/core/common/common-service/src/test/kotlin/com/tencent/devops/common/service/utils/JooqUtilsTest.kt
@@ -1,0 +1,34 @@
+package com.tencent.devops.common.service.utils
+
+import org.jooq.exception.DataAccessException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class JooqUtilsTest {
+
+    @Test
+    fun retryWhenDeadLock() {
+        var actual = 0
+        JooqUtils.retryWhenDeadLock {
+            if (actual++ < 1) {
+                throw DataAccessException("mock sql dead lock; ${JooqUtils.JooqDeadLockMessage}")
+            }
+        }
+        val expect = 2 // retry
+        Assertions.assertEquals(expect, actual)
+    }
+
+    @Test
+    fun assertThrowsRetryWhenDeadLock() {
+        var actual = 0
+        Assertions.assertThrows(DataAccessException::class.java) {
+            JooqUtils.retryWhenDeadLock {
+                if (actual++ < 1) {
+                    throw DataAccessException("mock sql no dead lock; ")
+                }
+            }
+        }
+        val expect = 1 // not retry
+        Assertions.assertEquals(expect, actual)
+    }
+}

--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/AtomFailInfoDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/AtomFailInfoDao.kt
@@ -28,7 +28,7 @@
 package com.tencent.devops.metrics.dao
 
 import com.tencent.devops.common.api.util.DateTimeUtil
-import com.tencent.devops.common.service.utils.JooqUtils.count
+import com.tencent.devops.common.db.utils.JooqUtils.count
 import com.tencent.devops.metrics.constant.Constants.BK_ATOM_CODE
 import com.tencent.devops.metrics.constant.Constants.BK_ATOM_NAME
 import com.tencent.devops.metrics.constant.Constants.BK_ATOM_POSITION

--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/AtomStatisticsDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/AtomStatisticsDao.kt
@@ -28,8 +28,8 @@
 package com.tencent.devops.metrics.dao
 
 import com.tencent.devops.common.api.util.DateTimeUtil
-import com.tencent.devops.common.service.utils.JooqUtils.productSum
-import com.tencent.devops.common.service.utils.JooqUtils.sum
+import com.tencent.devops.common.db.utils.JooqUtils.productSum
+import com.tencent.devops.common.db.utils.JooqUtils.sum
 import com.tencent.devops.metrics.constant.Constants
 import com.tencent.devops.metrics.constant.Constants.BK_ATOM_CODE
 import com.tencent.devops.metrics.constant.Constants.BK_ATOM_NAME

--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/PipelineFailDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/PipelineFailDao.kt
@@ -28,7 +28,7 @@
 package com.tencent.devops.metrics.dao
 
 import com.tencent.devops.common.api.util.DateTimeUtil
-import com.tencent.devops.common.service.utils.JooqUtils.sum
+import com.tencent.devops.common.db.utils.JooqUtils.sum
 import com.tencent.devops.metrics.config.MetricsConfig
 import com.tencent.devops.model.metrics.tables.TPipelineFailDetailData
 import com.tencent.devops.model.metrics.tables.TPipelineFailSummaryData

--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/PipelineOverviewDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/PipelineOverviewDao.kt
@@ -28,8 +28,8 @@
 package com.tencent.devops.metrics.dao
 
 import com.tencent.devops.common.api.util.DateTimeUtil
-import com.tencent.devops.common.service.utils.JooqUtils.productSum
-import com.tencent.devops.common.service.utils.JooqUtils.sum
+import com.tencent.devops.common.db.utils.JooqUtils.productSum
+import com.tencent.devops.common.db.utils.JooqUtils.sum
 import com.tencent.devops.metrics.constant.Constants.BK_FAIL_AVG_COST_TIME
 import com.tencent.devops.metrics.constant.Constants.BK_FAIL_EXECUTE_COUNT
 import com.tencent.devops.metrics.constant.Constants.BK_STATISTICS_TIME

--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/PipelineStageDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/PipelineStageDao.kt
@@ -28,7 +28,7 @@
 package com.tencent.devops.metrics.dao
 
 import com.tencent.devops.common.api.util.DateTimeUtil
-import com.tencent.devops.common.service.utils.JooqUtils.sum
+import com.tencent.devops.common.db.utils.JooqUtils.sum
 import com.tencent.devops.metrics.config.MetricsConfig
 import com.tencent.devops.metrics.constant.Constants
 import com.tencent.devops.metrics.constant.Constants.BK_AVG_COST_TIME

--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/ThirdPartyOverviewInfoDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/ThirdPartyOverviewInfoDao.kt
@@ -28,7 +28,7 @@
 package com.tencent.devops.metrics.dao
 
 import com.tencent.devops.common.api.util.DateTimeUtil
-import com.tencent.devops.common.service.utils.JooqUtils.sum
+import com.tencent.devops.common.db.utils.JooqUtils.sum
 import com.tencent.devops.metrics.constant.Constants.BK_QUALITY_PIPELINE_EXECUTE_NUM
 import com.tencent.devops.metrics.constant.Constants.BK_QUALITY_PIPELINE_INTERCEPTION_NUM
 import com.tencent.devops.metrics.constant.Constants.BK_REPO_CODECC_AVG_SCORE

--- a/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/dao/process/ProcessDataClearDao.kt
+++ b/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/dao/process/ProcessDataClearDao.kt
@@ -301,10 +301,16 @@ class ProcessDataClearDao {
         }
     }
 
-    fun deletePipelineBuildTemplateAcrossInfo(dslContext: DSLContext, projectId: String, buildId: String) {
+    fun deletePipelineBuildTemplateAcrossInfo(
+        dslContext: DSLContext,
+        projectId: String,
+        pipelineId: String,
+        buildId: String
+    ) {
         with(TPipelineBuildTemplateAcrossInfo.T_PIPELINE_BUILD_TEMPLATE_ACROSS_INFO) {
             dslContext.deleteFrom(this)
                 .where(PROJECT_ID.eq(projectId))
+                .and(PIPELINE_ID.eq(pipelineId))
                 .and(BUILD_ID.eq(buildId))
                 .execute()
         }

--- a/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/service/process/ProcessDataClearService.kt
+++ b/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/service/process/ProcessDataClearService.kt
@@ -28,7 +28,7 @@
 package com.tencent.devops.misc.service.process
 
 import com.tencent.devops.common.redis.RedisOperation
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.misc.dao.process.ProcessDao
 import com.tencent.devops.misc.dao.process.ProcessDataClearDao
 import com.tencent.devops.misc.lock.PipelineVersionLock

--- a/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/service/process/ProcessDataClearService.kt
+++ b/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/service/process/ProcessDataClearService.kt
@@ -28,6 +28,7 @@
 package com.tencent.devops.misc.service.process
 
 import com.tencent.devops.common.redis.RedisOperation
+import com.tencent.devops.common.service.utils.JooqUtils
 import com.tencent.devops.misc.dao.process.ProcessDao
 import com.tencent.devops.misc.dao.process.ProcessDataClearDao
 import com.tencent.devops.misc.lock.PipelineVersionLock
@@ -113,7 +114,9 @@ class ProcessDataClearService @Autowired constructor(
                 pipelineId = pipelineId,
                 buildId = buildId
             )
-            processDataClearDao.deletePipelineBuildTemplateAcrossInfo(context, projectId, buildId)
+            JooqUtils.retryWhenDeadLock {
+                processDataClearDao.deletePipelineBuildTemplateAcrossInfo(context, projectId, pipelineId, buildId)
+            }
             processDataClearDao.deleteBuildWebhookParameter(context, projectId, buildId)
             processDataClearDao.deleteBuildCommits(context, projectId, buildId)
             processDataClearDao.deleteBuildRecordPipelineByBuildId(context, projectId, buildId)

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/engine/common/Timeout.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/engine/common/Timeout.kt
@@ -67,7 +67,7 @@ object Timeout {
         return TimeoutObj(
             beforeChangeStr = timeoutStr,
             minutes = minute,
-            millis = TimeUnit.MINUTES.toMillis(minute.toLong()),
+            millis = transMinuteTimeoutToMills(minute),
             change = change
         )
     }

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -29,6 +29,7 @@ package com.tencent.devops.process.pojo.app
 
 import com.tencent.devops.common.api.constant.coerceAtMaxLength
 import com.tencent.devops.common.api.util.EnvUtils
+import com.tencent.devops.common.api.util.Watcher
 import com.tencent.devops.common.event.enums.ActionType
 import com.tencent.devops.common.pipeline.container.Container
 import com.tencent.devops.common.pipeline.container.Stage
@@ -121,6 +122,7 @@ data class StartBuildContext(
     // 注意：该字段在 PipelineContainerService.setUpTriggerContainer 中可能会被修改
     var currentBuildNo: Int? = null
 ) {
+    val watcher: Watcher = Watcher("startBuild-$buildId")
 
     /**
      * 检查Stage是否属于失败重试[stageRetry]时，当前[stage]是否需要跳过

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -215,6 +215,7 @@ data class StartBuildContext(
     companion object {
         private val logger = LoggerFactory.getLogger(StartBuildContext::class.java)
         private const val MAX_LENGTH = 255
+        private const val DELTA = 16
 
         fun init(
             projectId: String,
@@ -375,10 +376,10 @@ data class StartBuildContext(
             pipelineParamMap: MutableMap<String, BuildParameters>
         ): ArrayList<BuildParameters> {
 
-            val originStartParams = ArrayList<BuildParameters>(realStartParamKeys.size + 4)
+            val originStartParams = ArrayList<BuildParameters>(realStartParamKeys.size + DELTA)
 
             // 将用户定义的变量增加上下文前缀的版本，与原变量相互独立
-            val originStartContexts = HashMap<String, BuildParameters>(realStartParamKeys.size)
+            val originStartContexts = HashMap<String, BuildParameters>(realStartParamKeys.size, loadFactor = 1F)
             realStartParamKeys.forEach { key ->
                 pipelineParamMap[key]?.let { param ->
                     originStartParams.add(param)

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -379,7 +379,7 @@ data class StartBuildContext(
             val originStartParams = ArrayList<BuildParameters>(realStartParamKeys.size + DELTA)
 
             // 将用户定义的变量增加上下文前缀的版本，与原变量相互独立
-            val originStartContexts = HashMap<String, BuildParameters>(realStartParamKeys.size, loadFactor = 1F)
+            val originStartContexts = HashMap<String, BuildParameters>(realStartParamKeys.size, /* loadFactor */ 1F)
             realStartParamKeys.forEach { key ->
                 pipelineParamMap[key]?.let { param ->
                     originStartParams.add(param)

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -84,6 +84,7 @@ import java.time.LocalDateTime
 /**
  * 启动流水线上下文类，属于非线程安全类
  */
+@Suppress("ComplexMethod")
 data class StartBuildContext(
     val now: LocalDateTime = LocalDateTime.now(),
     val projectId: String,

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/pipeline/record/BuildRecordContainer.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/pipeline/record/BuildRecordContainer.kt
@@ -77,10 +77,6 @@ data class BuildRecordContainer(
     companion object {
 
         fun MutableList<BuildRecordContainer>.addRecords(
-            projectId: String,
-            pipelineId: String,
-            version: Int,
-            buildId: String,
             stage: Stage,
             container: Container,
             context: StartBuildContext,
@@ -107,22 +103,37 @@ data class BuildRecordContainer(
             }
             this.add(
                 BuildRecordContainer(
-                    projectId = projectId, pipelineId = pipelineId, resourceVersion = version,
-                    buildId = buildId, stageId = stage.id!!, containerId = container.containerId!!,
-                    containerType = container.getClassType(), executeCount = context.executeCount,
-                    matrixGroupFlag = container.matrixGroupFlag, status = buildStatus?.name,
-                    containerVar = containerVar, timestamps = mapOf()
+                    projectId = context.projectId,
+                    pipelineId = context.pipelineId,
+                    resourceVersion = context.resourceVersion,
+                    buildId = context.buildId,
+                    stageId = stage.id!!,
+                    containerId = container.containerId!!,
+                    containerType = container.getClassType(),
+                    executeCount = context.executeCount,
+                    matrixGroupFlag = container.matrixGroupFlag,
+                    status = buildStatus?.name,
+                    containerVar = containerVar,
+                    timestamps = mapOf()
                 )
             )
             container.elements.forEachIndexed { index, element ->
                 taskBuildRecords.add(
                     BuildRecordTask(
-                        projectId = projectId, pipelineId = pipelineId, buildId = buildId,
-                        stageId = stage.id!!, containerId = container.containerId!!,
-                        taskId = element.id!!, classType = element.getClassType(),
-                        atomCode = element.getTaskAtom(), executeCount = context.executeCount,
-                        resourceVersion = version, taskSeq = index, status = buildStatus?.name,
-                        taskVar = mutableMapOf(), timestamps = mapOf()
+                        projectId = context.projectId,
+                        pipelineId = context.pipelineId,
+                        buildId = context.buildId,
+                        stageId = stage.id!!,
+                        containerId = container.containerId!!,
+                        taskId = element.id!!,
+                        classType = element.getClassType(),
+                        atomCode = element.getTaskAtom(),
+                        executeCount = context.executeCount,
+                        resourceVersion = context.resourceVersion,
+                        taskSeq = index,
+                        status = buildStatus?.name,
+                        taskVar = mutableMapOf(),
+                        timestamps = mapOf()
                     )
                 )
             }

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/pipeline/record/BuildRecordStage.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/pipeline/record/BuildRecordStage.kt
@@ -66,10 +66,6 @@ data class BuildRecordStage(
 ) {
     companion object {
         fun MutableList<BuildRecordStage>.addRecords(
-            projectId: String,
-            pipelineId: String,
-            version: Int,
-            buildId: String,
             stage: Stage,
             context: StartBuildContext,
             stageIndex: Int,
@@ -79,16 +75,25 @@ data class BuildRecordStage(
         ) {
             this.add(
                 BuildRecordStage(
-                    projectId = projectId, pipelineId = pipelineId, resourceVersion = version,
-                    buildId = buildId, stageId = stage.id!!, executeCount = context.executeCount,
-                    stageSeq = stageIndex, stageVar = mutableMapOf(), status = buildStatus?.name,
+                    projectId = context.projectId,
+                    pipelineId = context.pipelineId,
+                    resourceVersion = context.resourceVersion,
+                    buildId = context.buildId,
+                    stageId = stage.id!!,
+                    executeCount = context.executeCount,
+                    stageSeq = stageIndex,
+                    stageVar = mutableMapOf(),
+                    status = buildStatus?.name,
                     timestamps = mapOf()
                 )
             )
             stage.containers.forEach { container ->
                 containerBuildRecords.addRecords(
-                    projectId, pipelineId, version, buildId, stage, container,
-                    context, buildStatus, taskBuildRecords
+                    stage = stage,
+                    container = container,
+                    context = context,
+                    buildStatus = buildStatus,
+                    taskBuildRecords = taskBuildRecords
                 )
             }
         }

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/setting/PipelineSetting.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/setting/PipelineSetting.kt
@@ -33,7 +33,6 @@ import com.tencent.devops.common.web.annotation.BkField
 import com.tencent.devops.common.web.constant.BkStyleEnum
 import com.tencent.devops.process.utils.PIPELINE_RES_NUM_MIN
 import com.tencent.devops.process.utils.PIPELINE_SETTING_CONCURRENCY_GROUP_DEFAULT
-import com.tencent.devops.process.utils.PIPELINE_SETTING_MAX_CON_QUEUE_SIZE_DEFAULT
 import com.tencent.devops.process.utils.PIPELINE_SETTING_MAX_CON_QUEUE_SIZE_MAX
 import com.tencent.devops.process.utils.PIPELINE_SETTING_MAX_QUEUE_SIZE_DEFAULT
 import com.tencent.devops.process.utils.PIPELINE_SETTING_MAX_QUEUE_SIZE_MAX
@@ -75,7 +74,7 @@ data class PipelineSetting(
     @ApiModelProperty("保存流水线编排的最大个数", required = false)
     val maxPipelineResNum: Int = PIPELINE_RES_NUM_MIN, // 保存流水线编排的最大个数
     @ApiModelProperty("并发构建数量限制", required = false)
-    val maxConRunningQueueSize: Int? = PIPELINE_SETTING_MAX_CON_QUEUE_SIZE_DEFAULT, // MULTIPLE类型时，并发构建数量限制
+    val maxConRunningQueueSize: Int? = PIPELINE_SETTING_MAX_CON_QUEUE_SIZE_MAX, // MULTIPLE类型时，并发构建数量限制
     @ApiModelProperty("版本", required = false)
     var version: Int = 0,
     @field:BkField(patternStyle = BkStyleEnum.BUILD_NUM_RULE_STYLE, required = false)

--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/utils/PipelineVarUtil.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/utils/PipelineVarUtil.kt
@@ -27,6 +27,7 @@
 
 package com.tencent.devops.process.utils
 
+import com.tencent.devops.common.api.constant.coerceAtMaxLength
 import com.tencent.devops.common.pipeline.enums.BuildFormPropertyType
 import com.tencent.devops.common.pipeline.pojo.BuildParameters
 import com.tencent.devops.common.pipeline.utils.PIPELINE_GIT_ACTION
@@ -62,7 +63,6 @@ import com.tencent.devops.common.pipeline.utils.PIPELINE_GIT_TAG_FROM
 import com.tencent.devops.common.pipeline.utils.PIPELINE_GIT_TAG_MESSAGE
 import com.tencent.devops.common.pipeline.utils.PIPELINE_GIT_UPDATE_USER
 import com.tencent.devops.common.pipeline.utils.PIPELINE_GIT_YAML_PATH
-import com.tencent.devops.common.service.utils.CommonUtils
 import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_ISSUE_DESCRIPTION
 import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_ISSUE_ID
 import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_ISSUE_IID
@@ -457,7 +457,7 @@ object PipelineVarUtil {
         val buildNo = buildParameters.firstOrNull { it.key == BUILD_NO || it.key == "BuildNo" }?.value?.toString()
             ?: return null
 
-        return CommonUtils.interceptStringInLength("$recommendVersionPrefix.$buildNo", MAX_VERSION_LEN)
+        return "$recommendVersionPrefix.$buildNo".coerceAtMaxLength(MAX_VERSION_LEN)
     }
 
     /**

--- a/src/backend/ci/core/process/api-process/src/test/kotlin/com/tencent/devops/process/utils/PipelineVarUtilTest.kt
+++ b/src/backend/ci/core/process/api-process/src/test/kotlin/com/tencent/devops/process/utils/PipelineVarUtilTest.kt
@@ -28,10 +28,10 @@
 package com.tencent.devops.process.utils
 
 import com.fasterxml.jackson.core.type.TypeReference
+import com.tencent.devops.common.api.constant.coerceAtMaxLength
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.pipeline.enums.BuildFormPropertyType
 import com.tencent.devops.common.pipeline.pojo.BuildParameters
-import com.tencent.devops.common.service.utils.CommonUtils
 import com.tencent.devops.common.pipeline.enums.BuildRecordTimeStamp
 import com.tencent.devops.common.pipeline.pojo.time.BuildTimestampType
 import com.tencent.devops.common.webhook.pojo.code.PIPELINE_REPO_NAME
@@ -310,12 +310,10 @@ class PipelineVarUtilTest {
         plist.add(BuildParameters(key = MINORVERSION, value = illegalMinor, valueType = BuildFormPropertyType.STRING))
         plist.add(BuildParameters(key = FIXVERSION, value = illegalFixVer, valueType = BuildFormPropertyType.STRING))
         plist.add(BuildParameters(key = BUILD_NO, value = illegalBuildNo, valueType = BuildFormPropertyType.STRING))
-        val expectCut = CommonUtils.interceptStringInLength(
-            illegalMajor
+        val expectCut = illegalMajor
                 .plus(".").plus(illegalMinor)
                 .plus(".").plus(illegalFixVer)
-                .plus(".").plus(illegalBuildNo), MAX_VERSION_LEN
-        )
+                .plus(".").plus(illegalBuildNo).coerceAtMaxLength(MAX_VERSION_LEN)
         actual = PipelineVarUtil.getRecommendVersion(plist)
         assertEquals(expectCut, actual)
     }

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/BuildDetailDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/BuildDetailDao.kt
@@ -44,23 +44,6 @@ class BuildDetailDao {
         dslContext: DSLContext,
         projectId: String,
         buildId: String,
-        model: String
-    ) {
-        create(
-            dslContext = dslContext,
-            projectId = projectId,
-            buildId = buildId,
-            startUser = "",
-            startType = null,
-            buildNum = null,
-            model = model
-        )
-    }
-
-    fun create(
-        dslContext: DSLContext,
-        projectId: String,
-        buildId: String,
         startUser: String,
         startType: StartType?,
         buildNum: Int?,
@@ -103,18 +86,6 @@ class BuildDetailDao {
                 .where(PROJECT_ID.eq(projectId))
                 .and(BUILD_ID.eq(buildId))
                 .execute()
-        }
-    }
-
-    fun getBuildCancelUser(
-        dslContext: DSLContext,
-        projectId: String,
-        buildId: String
-    ): String? {
-        with(TPipelineBuildDetail.T_PIPELINE_BUILD_DETAIL) {
-            return dslContext.select(CANCEL_USER).from(this)
-                .where(PROJECT_ID.eq(projectId).and(BUILD_ID.eq(buildId)))
-                .fetchOne(0, String::class.java)
         }
     }
 
@@ -163,18 +134,6 @@ class BuildDetailDao {
                 execute.set(END_TIME, LocalDateTime.now())
             }
             execute.where(PROJECT_ID.eq(projectId).and(BUILD_ID.eq(buildId))).execute()
-        }
-    }
-
-    fun updateModel(
-        dslContext: DSLContext,
-        projectId: String,
-        buildId: String,
-        model: String
-    ) {
-        with(TPipelineBuildDetail.T_PIPELINE_BUILD_DETAIL) {
-            dslContext.update(this).set(MODEL, model)
-                .where(PROJECT_ID.eq(projectId).and(BUILD_ID.eq(buildId))).execute()
         }
     }
 

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/PipelineBuildTemplateAcrossInfoDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/PipelineBuildTemplateAcrossInfoDao.kt
@@ -102,7 +102,7 @@ class PipelineBuildTemplateAcrossInfoDao {
             dslContext.batched { c ->
                 templateAcrossInfos.forEach { info ->
                     c.dsl().update(this)
-                        .set(TEMPLATE_INSTANCE_IDS, JsonUtil.toJson(info.templateInstancesIds))
+                        .set(TEMPLATE_INSTANCE_IDS, JsonUtil.toJson(info.templateInstancesIds, formatted = false))
                         .where(PROJECT_ID.eq(projectId))
                         .and(PIPELINE_ID.eq(pipelineId))
                         .and(BUILD_ID.eq(buildId))

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/record/BuildRecordStageDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/record/BuildRecordStageDao.kt
@@ -41,6 +41,7 @@ import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.RecordMapper
 import org.jooq.impl.DSL
+import org.jooq.util.mysql.MySQLDSL
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -50,26 +51,40 @@ class BuildRecordStageDao {
 
     fun batchSave(dslContext: DSLContext, records: List<BuildRecordStage>) {
         with(TPipelineBuildRecordStage.T_PIPELINE_BUILD_RECORD_STAGE) {
-            records.forEach { record ->
-                dslContext.insertInto(this)
-                    .set(BUILD_ID, record.buildId)
-                    .set(PROJECT_ID, record.projectId)
-                    .set(PIPELINE_ID, record.pipelineId)
-                    .set(RESOURCE_VERSION, record.resourceVersion)
-                    .set(STAGE_ID, record.stageId)
-                    .set(EXECUTE_COUNT, record.executeCount)
-                    .set(SEQ, record.stageSeq)
-                    .set(STAGE_VAR, JsonUtil.toJson(record.stageVar, false))
-                    .set(STATUS, record.status)
-                    .set(TIMESTAMPS, JsonUtil.toJson(record.timestamps, false))
-                    .onDuplicateKeyUpdate()
-                    .set(STAGE_VAR, JsonUtil.toJson(record.stageVar, false))
-                    .set(STATUS, record.status)
-                    .set(START_TIME, record.startTime)
-                    .set(END_TIME, record.endTime)
-                    .set(TIMESTAMPS, JsonUtil.toJson(record.timestamps, false))
-                    .execute()
-            }
+            dslContext.insertInto(
+                this,
+                BUILD_ID,
+                PROJECT_ID,
+                PIPELINE_ID,
+                RESOURCE_VERSION,
+                STAGE_ID,
+                EXECUTE_COUNT,
+                SEQ,
+                STAGE_VAR,
+                STATUS,
+                TIMESTAMPS
+            ).also { insertSetStep ->
+                records.forEach { record ->
+                    insertSetStep.values(
+                        record.buildId,
+                        record.projectId,
+                        record.pipelineId,
+                        record.resourceVersion,
+                        record.stageId,
+                        record.executeCount,
+                        record.stageSeq,
+                        JsonUtil.toJson(record.stageVar, false),
+                        record.status,
+                        JsonUtil.toJson(record.timestamps, false)
+                    )
+                }
+            }.onDuplicateKeyUpdate()
+                .set(STATUS, MySQLDSL.values(STATUS))
+                .set(START_TIME, MySQLDSL.values(START_TIME))
+                .set(END_TIME, MySQLDSL.values(END_TIME))
+                .set(TIMESTAMPS, MySQLDSL.values(TIMESTAMPS))
+                .set(STAGE_VAR, MySQLDSL.values(STAGE_VAR))
+                .execute()
         }
     }
 

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/record/BuildRecordTaskDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/dao/record/BuildRecordTaskDao.kt
@@ -42,6 +42,7 @@ import org.jooq.DSLContext
 import org.jooq.Record17
 import org.jooq.RecordMapper
 import org.jooq.impl.DSL
+import org.jooq.util.mysql.MySQLDSL
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -51,31 +52,51 @@ class BuildRecordTaskDao {
 
     fun batchSave(dslContext: DSLContext, records: List<BuildRecordTask>) {
         with(TPipelineBuildRecordTask.T_PIPELINE_BUILD_RECORD_TASK) {
-            records.forEach { record ->
-                dslContext.insertInto(this)
-                    .set(BUILD_ID, record.buildId)
-                    .set(PROJECT_ID, record.projectId)
-                    .set(PIPELINE_ID, record.pipelineId)
-                    .set(RESOURCE_VERSION, record.resourceVersion)
-                    .set(STAGE_ID, record.stageId)
-                    .set(CONTAINER_ID, record.containerId)
-                    .set(TASK_ID, record.taskId)
-                    .set(EXECUTE_COUNT, record.executeCount)
-                    .set(CLASS_TYPE, record.classType)
-                    .set(ORIGIN_CLASS_TYPE, record.originClassType)
-                    .set(TASK_VAR, JsonUtil.toJson(record.taskVar, false))
-                    .set(STATUS, record.status)
-                    .set(TASK_SEQ, record.taskSeq)
-                    .set(ATOM_CODE, record.atomCode)
-                    .set(TIMESTAMPS, JsonUtil.toJson(record.timestamps, false))
-                    .onDuplicateKeyUpdate()
-                    .set(TASK_VAR, JsonUtil.toJson(record.taskVar, false))
-                    .set(STATUS, record.status)
-                    .set(START_TIME, record.startTime)
-                    .set(END_TIME, record.endTime)
-                    .set(TIMESTAMPS, JsonUtil.toJson(record.timestamps, false))
-                    .execute()
-            }
+
+            dslContext.insertInto(
+                this,
+                BUILD_ID,
+                PROJECT_ID,
+                PIPELINE_ID,
+                RESOURCE_VERSION,
+                STAGE_ID,
+                CONTAINER_ID,
+                TASK_ID,
+                EXECUTE_COUNT,
+                CLASS_TYPE,
+                ORIGIN_CLASS_TYPE,
+                TASK_VAR,
+                STATUS,
+                TASK_SEQ,
+                ATOM_CODE,
+                TIMESTAMPS
+            ).also { insert ->
+                records.forEach { record ->
+                    insert.values(
+                        record.buildId,
+                        record.projectId,
+                        record.pipelineId,
+                        record.resourceVersion,
+                        record.stageId,
+                        record.containerId,
+                        record.taskId,
+                        record.executeCount,
+                        record.classType,
+                        record.originClassType,
+                        JsonUtil.toJson(record.taskVar, false),
+                        record.status,
+                        record.taskSeq,
+                        record.atomCode,
+                        JsonUtil.toJson(record.timestamps, false)
+                    )
+                }
+            }.onDuplicateKeyUpdate()
+                .set(STATUS, MySQLDSL.values(STATUS))
+                .set(START_TIME, MySQLDSL.values(START_TIME))
+                .set(END_TIME, MySQLDSL.values(END_TIME))
+                .set(TIMESTAMPS, MySQLDSL.values(TIMESTAMPS))
+                .set(TASK_VAR, MySQLDSL.values(TASK_VAR))
+                .execute()
         }
     }
 

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/BuildIdLock.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/BuildIdLock.kt
@@ -31,7 +31,12 @@ import com.tencent.devops.common.redis.RedisLock
 import com.tencent.devops.common.redis.RedisOperation
 
 class BuildIdLock(redisOperation: RedisOperation, buildId: String) :
-    RedisLock(redisOperation = redisOperation, lockKey = "lock:build:$buildId:run", expiredTimeInSeconds = 30L) {
+    RedisLock(
+        redisOperation = redisOperation,
+        lockKey = "lock:build:$buildId:run",
+        expiredTimeInSeconds = 30L,
+        sleepTime = 10L // 10ms
+    ) {
     override fun decorateKey(key: String): String {
         // buildId在各集群唯一，key无需加上集群信息前缀来区分
         return key

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineBuildNoLock.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineBuildNoLock.kt
@@ -34,7 +34,8 @@ class PipelineBuildNoLock(redisOperation: RedisOperation, pipelineId: String) :
     RedisLock(
         redisOperation = redisOperation,
         lockKey = "lock:pipeline:$pipelineId:buildNo",
-        expiredTimeInSeconds = 30L
+        expiredTimeInSeconds = 30L,
+        sleepTime = 10L
     ) {
     override fun decorateKey(key: String): String {
         // pipelineId在各集群唯一，key无需加上集群信息前缀来区分

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineBuildNumAliasLock.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineBuildNumAliasLock.kt
@@ -30,11 +30,12 @@ package com.tencent.devops.process.engine.control.lock
 import com.tencent.devops.common.redis.RedisLock
 import com.tencent.devops.common.redis.RedisOperation
 
-class PipelineBuildHistoryLock(redisOperation: RedisOperation, pipelineId: String) :
+class PipelineBuildNumAliasLock(redisOperation: RedisOperation, pipelineId: String) :
     RedisLock(
         redisOperation = redisOperation,
         lockKey = "process:build:history:lock:$pipelineId",
-        expiredTimeInSeconds = 10L
+        expiredTimeInSeconds = 10L,
+        sleepTime = 10L
     ) {
     override fun decorateKey(key: String): String {
         // pipelineId在各集群唯一，key无需加上集群信息前缀来区分

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineBuildRunLock.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineBuildRunLock.kt
@@ -34,6 +34,7 @@ class PipelineBuildRunLock(redisOperation: RedisOperation, pipelineId: String) :
     RedisLock(
         redisOperation = redisOperation,
         lockKey = "build:limit:$pipelineId",
+        sleepTime = 10L,
         expiredTimeInSeconds = 30L
     ) {
     override fun decorateKey(key: String): String {

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineVersionLock.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/control/lock/PipelineVersionLock.kt
@@ -34,7 +34,8 @@ class PipelineVersionLock(redisOperation: RedisOperation, pipelineId: String, ve
     RedisLock(
         redisOperation = redisOperation,
         lockKey = "lock:pipeline:$pipelineId:version:$version",
-        expiredTimeInSeconds = 30L
+        expiredTimeInSeconds = 30L,
+        sleepTime = 10L
     ) {
     override fun decorateKey(key: String): String {
         // pipelineId在各集群唯一，key无需加上集群信息前缀来区分

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildContainerDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildContainerDao.kt
@@ -38,6 +38,7 @@ import com.tencent.devops.process.engine.pojo.PipelineBuildContainerControlOptio
 import org.jooq.DSLContext
 import org.jooq.DatePart
 import org.jooq.RecordMapper
+import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -46,10 +47,7 @@ import java.time.LocalDateTime
 @Repository
 class PipelineBuildContainerDao {
 
-    fun create(
-        dslContext: DSLContext,
-        buildContainer: PipelineBuildContainer
-    ) {
+    fun create(dslContext: DSLContext, buildContainer: PipelineBuildContainer) {
 
         val count =
             with(T_PIPELINE_BUILD_CONTAINER) {
@@ -97,32 +95,52 @@ class PipelineBuildContainerDao {
 
     fun batchSave(dslContext: DSLContext, containerList: Collection<PipelineBuildContainer>) {
         with(T_PIPELINE_BUILD_CONTAINER) {
-            containerList.forEach {
-                dslContext.insertInto(this)
-                    .set(PROJECT_ID, it.projectId)
-                    .set(PIPELINE_ID, it.pipelineId)
-                    .set(BUILD_ID, it.buildId)
-                    .set(STAGE_ID, it.stageId)
-                    .set(CONTAINER_ID, it.containerId)
-                    .set(CONTAINER_HASH_ID, it.containerHashId)
-                    .set(MATRIX_GROUP_FLAG, it.matrixGroupFlag)
-                    .set(MATRIX_GROUP_ID, it.matrixGroupId)
-                    .set(CONTAINER_TYPE, it.containerType)
-                    .set(SEQ, it.seq)
-                    .set(STATUS, it.status.ordinal)
-                    .set(START_TIME, it.startTime)
-                    .set(END_TIME, it.endTime)
-                    .set(COST, it.cost)
-                    .set(EXECUTE_COUNT, it.executeCount)
-                    .set(CONDITIONS, it.controlOption.let { self -> JsonUtil.toJson(self, formatted = false) })
-                    .onDuplicateKeyUpdate()
-                    .set(STATUS, it.status.ordinal)
-                    .set(START_TIME, it.startTime)
-                    .set(END_TIME, it.endTime)
-                    .set(COST, it.cost)
-                    .set(EXECUTE_COUNT, it.executeCount)
-                    .execute()
-            }
+            dslContext.insertInto(
+                this,
+                PROJECT_ID,
+                PIPELINE_ID,
+                BUILD_ID,
+                STAGE_ID,
+                CONTAINER_ID,
+                CONTAINER_HASH_ID,
+                MATRIX_GROUP_FLAG,
+                MATRIX_GROUP_ID,
+                CONTAINER_TYPE,
+                SEQ,
+                STATUS,
+                START_TIME,
+                END_TIME,
+                COST,
+                EXECUTE_COUNT,
+                CONDITIONS
+            ).also { insert ->
+                containerList.forEach {
+                    insert.values(
+                        it.projectId,
+                        it.pipelineId,
+                        it.buildId,
+                        it.stageId,
+                        it.containerId,
+                        it.containerHashId,
+                        it.matrixGroupFlag,
+                        it.matrixGroupId,
+                        it.containerType,
+                        it.seq,
+                        it.status.ordinal,
+                        it.startTime,
+                        it.endTime,
+                        it.cost,
+                        it.executeCount,
+                        it.controlOption.let { self -> JsonUtil.toJson(self, formatted = false) }
+                    )
+                }
+            }.onDuplicateKeyUpdate()
+                .set(STATUS, MySQLDSL.values(STATUS))
+                .set(START_TIME, MySQLDSL.values(START_TIME))
+                .set(END_TIME, MySQLDSL.values(END_TIME))
+                .set(COST, MySQLDSL.values(COST))
+                .set(EXECUTE_COUNT, MySQLDSL.values(EXECUTE_COUNT))
+                .execute()
         }
     }
 

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildContainerDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildContainerDao.kt
@@ -30,7 +30,7 @@ package com.tencent.devops.process.engine.dao
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.option.JobControlOption
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.process.Tables.T_PIPELINE_BUILD_CONTAINER
 import com.tencent.devops.model.process.tables.records.TPipelineBuildContainerRecord
 import com.tencent.devops.process.engine.pojo.PipelineBuildContainer

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildDao.kt
@@ -37,7 +37,7 @@ import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ChannelCode
 import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.common.pipeline.pojo.BuildParameters
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.process.Tables.T_PIPELINE_BUILD_HISTORY
 import com.tencent.devops.model.process.tables.TPipelineBuildHistory
 import com.tencent.devops.model.process.tables.records.TPipelineBuildHistoryRecord

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildDao.kt
@@ -38,6 +38,7 @@ import com.tencent.devops.common.pipeline.enums.ChannelCode
 import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.common.pipeline.pojo.BuildParameters
 import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.webhook.pojo.code.PIPELINE_WEBHOOK_TYPE
 import com.tencent.devops.model.process.Tables.T_PIPELINE_BUILD_HISTORY
 import com.tencent.devops.model.process.tables.TPipelineBuildHistory
 import com.tencent.devops.model.process.tables.records.TPipelineBuildHistoryRecord
@@ -45,6 +46,7 @@ import com.tencent.devops.process.constant.ProcessMessageCode
 import com.tencent.devops.process.engine.pojo.BuildInfo
 import com.tencent.devops.process.pojo.BuildStageStatus
 import com.tencent.devops.process.pojo.PipelineBuildMaterial
+import com.tencent.devops.process.pojo.app.StartBuildContext
 import com.tencent.devops.process.pojo.code.WebhookInfo
 import org.jooq.Condition
 import org.jooq.DSLContext
@@ -65,29 +67,7 @@ class PipelineBuildDao {
         private const val DEFAULT_PAGE_SIZE = 10
     }
 
-    fun create(
-        dslContext: DSLContext,
-        projectId: String,
-        pipelineId: String,
-        buildId: String,
-        version: Int,
-        buildNum: Int,
-        trigger: String,
-        status: BuildStatus,
-        startUser: String,
-        triggerUser: String,
-        taskCount: Int,
-        firstTaskId: String,
-        channelCode: ChannelCode,
-        parentBuildId: String?,
-        parentTaskId: String?,
-        buildParameters: List<BuildParameters>,
-        webhookType: String?,
-        webhookInfo: String?,
-        buildMsg: String?,
-        buildNumAlias: String? = null,
-        concurrencyGroup: String? = null
-    ) {
+    fun create(dslContext: DSLContext, startBuildContext: StartBuildContext) {
         try {
             with(T_PIPELINE_BUILD_HISTORY) {
                 dslContext.insertInto(
@@ -114,27 +94,27 @@ class PipelineBuildDao {
                     BUILD_NUM_ALIAS,
                     CONCURRENCY_GROUP
                 ).values(
-                    buildId,
-                    buildNum,
-                    projectId,
-                    pipelineId,
-                    parentBuildId,
-                    parentTaskId,
-                    startUser,
-                    triggerUser,
-                    status.ordinal,
-                    trigger,
-                    taskCount,
-                    firstTaskId,
-                    channelCode.name,
-                    version,
+                    startBuildContext.buildId,
+                    startBuildContext.buildNum,
+                    startBuildContext.projectId,
+                    startBuildContext.pipelineId,
+                    startBuildContext.parentBuildId,
+                    startBuildContext.parentTaskId,
+                    startBuildContext.userId,
+                    startBuildContext.triggerUser,
+                    startBuildContext.startBuildStatus.ordinal,
+                    startBuildContext.startType.name,
+                    startBuildContext.taskCount,
+                    startBuildContext.firstTaskId,
+                    startBuildContext.channelCode.name,
+                    startBuildContext.resourceVersion,
                     LocalDateTime.now(),
-                    JsonUtil.toJson(buildParameters, formatted = false),
-                    webhookType,
-                    webhookInfo,
-                    buildMsg,
-                    buildNumAlias,
-                    concurrencyGroup
+                    JsonUtil.toJson(startBuildContext.buildParameters, formatted = false),
+                    startBuildContext.variables[PIPELINE_WEBHOOK_TYPE],
+                    startBuildContext.webhookInfo?.let { self -> JsonUtil.toJson(self, formatted = false) },
+                    startBuildContext.buildMsg,
+                    startBuildContext.buildNumAlias,
+                    startBuildContext.concurrencyGroup
                 ).execute()
             }
         } catch (t: Throwable) {
@@ -159,12 +139,8 @@ class PipelineBuildDao {
             val where = dslContext.selectFrom(this)
                 .where(PROJECT_ID.eq(projectId))
                 .and(PIPELINE_ID.eq(pipelineId))
-            if (statusSet != null && statusSet.isNotEmpty()) {
-                val statusIntSet = mutableSetOf<Int>()
-                statusSet.forEach {
-                    statusIntSet.add(it.ordinal)
-                }
-                where.and(STATUS.`in`(statusIntSet))
+            if (!statusSet.isNullOrEmpty()) {
+                where.and(STATUS.`in`(statusSet.map { it.ordinal }))
             }
             where.fetch()
         }
@@ -301,12 +277,8 @@ class PipelineBuildDao {
                 .where(PROJECT_ID.eq(projectId))
                 .and(PIPELINE_ID.eq(pipelineId))
 
-            if (statusSet != null && statusSet.isNotEmpty()) {
-                val statusIntSet = mutableSetOf<Int>()
-                statusSet.forEach {
-                    statusIntSet.add(it.ordinal)
-                }
-                select.and(STATUS.`in`(statusIntSet))
+            if (!statusSet.isNullOrEmpty()) {
+                select.and(STATUS.`in`(statusSet.map { it.ordinal }))
             }
 
             if (buildNum != null && buildNum > 0) {
@@ -711,12 +683,12 @@ class PipelineBuildDao {
             var conditionsOr: Condition
 
             conditionsOr = JooqUtils.jsonExtract(t1 = MATERIAL, t2 = "\$[*].aliasName", lower = true)
-                .like("%${materialAlias.first().toLowerCase()}%")
+                .like("%${materialAlias.first().lowercase()}%")
 
             materialAlias.forEachIndexed { index, s ->
                 if (index == 0) return@forEachIndexed
                 conditionsOr = conditionsOr.or(
-                    JooqUtils.jsonExtract(MATERIAL, "\$[*].aliasName", lower = true).like("%${s.toLowerCase()}%")
+                    JooqUtils.jsonExtract(MATERIAL, "\$[*].aliasName", lower = true).like("%${s.lowercase()}%")
                 )
             }
             where.and(conditionsOr)
@@ -730,12 +702,12 @@ class PipelineBuildDao {
             var conditionsOr: Condition
 
             conditionsOr = JooqUtils.jsonExtract(MATERIAL, "\$[*].branchName", lower = true)
-                .like("%${materialBranch.first().toLowerCase()}%")
+                .like("%${materialBranch.first().lowercase()}%")
 
             materialBranch.forEachIndexed { index, s ->
                 if (index == 0) return@forEachIndexed
                 conditionsOr = conditionsOr.or(
-                    JooqUtils.jsonExtract(MATERIAL, "\$[*].branchName", lower = true).like("%${s.toLowerCase()}%")
+                    JooqUtils.jsonExtract(MATERIAL, "\$[*].branchName", lower = true).like("%${s.lowercase()}%")
                 )
             }
             where.and(conditionsOr)
@@ -791,7 +763,7 @@ class PipelineBuildDao {
                 ).lessOrEqual(totalTimeMax)
             )
         }
-        if (remark != null && remark.isNotEmpty()) {
+        if (!remark.isNullOrBlank()) {
             where.and(REMARK.like("%$remark%"))
         }
         if (buildNoStart != null && buildNoStart > 0) {
@@ -800,7 +772,7 @@ class PipelineBuildDao {
         if (buildNoEnd != null && buildNoEnd > 0) {
             where.and(BUILD_NUM.le(buildNoEnd))
         }
-        if (buildMsg != null && buildMsg.isNotEmpty()) {
+        if (!buildMsg.isNullOrBlank()) {
             where.and(BUILD_MSG.like("%$buildMsg%"))
         }
     }

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildStageDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildStageDao.kt
@@ -40,6 +40,7 @@ import com.tencent.devops.process.engine.pojo.PipelineBuildStageControlOption
 import org.jooq.DSLContext
 import org.jooq.DatePart
 import org.jooq.RecordMapper
+import org.jooq.util.mysql.MySQLDSL
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -48,10 +49,7 @@ import java.time.LocalDateTime
 @Repository
 class PipelineBuildStageDao {
 
-    fun create(
-        dslContext: DSLContext,
-        buildStage: PipelineBuildStage
-    ) {
+    fun create(dslContext: DSLContext, buildStage: PipelineBuildStage) {
 
         val count = with(T_PIPELINE_BUILD_STAGE) {
             dslContext.insertInto(
@@ -92,29 +90,46 @@ class PipelineBuildStageDao {
 
     fun batchSave(dslContext: DSLContext, stageList: Collection<PipelineBuildStage>) {
         with(T_PIPELINE_BUILD_STAGE) {
-            stageList.forEach {
-                dslContext.insertInto(this)
-                    .set(PROJECT_ID, it.projectId)
-                    .set(PIPELINE_ID, it.pipelineId)
-                    .set(BUILD_ID, it.buildId)
-                    .set(STAGE_ID, it.stageId)
-                    .set(SEQ, it.seq)
-                    .set(STATUS, it.status.ordinal)
-                    .set(START_TIME, it.startTime)
-                    .set(END_TIME, it.endTime)
-                    .set(COST, it.cost)
-                    .set(EXECUTE_COUNT, it.executeCount)
-                    .set(CONDITIONS, it.controlOption?.let { self -> JsonUtil.toJson(self, formatted = false) })
-                    .set(CHECK_IN, it.checkIn?.let { self -> JsonUtil.toJson(self, formatted = false) })
-                    .set(CHECK_OUT, it.checkOut?.let { self -> JsonUtil.toJson(self, formatted = false) })
-                    .onDuplicateKeyUpdate()
-                    .set(STATUS, it.status.ordinal)
-                    .set(START_TIME, it.startTime)
-                    .set(END_TIME, it.endTime)
-                    .set(COST, it.cost)
-                    .set(EXECUTE_COUNT, it.executeCount)
-                    .execute()
-            }
+            dslContext.insertInto(
+                this,
+                PROJECT_ID,
+                PIPELINE_ID,
+                BUILD_ID,
+                STAGE_ID,
+                SEQ,
+                STATUS,
+                START_TIME,
+                END_TIME,
+                COST,
+                EXECUTE_COUNT,
+                CONDITIONS,
+                CHECK_IN,
+                CHECK_OUT
+            ).also { insert ->
+                stageList.forEach {
+                    insert.values(
+                        it.projectId,
+                        it.pipelineId,
+                        it.buildId,
+                        it.stageId,
+                        it.seq,
+                        it.status.ordinal,
+                        it.startTime,
+                        it.endTime,
+                        it.cost,
+                        it.executeCount,
+                        it.controlOption?.let { self -> JsonUtil.toJson(self, formatted = false) },
+                        it.checkIn?.let { self -> JsonUtil.toJson(self, formatted = false) },
+                        it.checkOut?.let { self -> JsonUtil.toJson(self, formatted = false) }
+                    )
+                }
+            }.onDuplicateKeyUpdate()
+                .set(STATUS, MySQLDSL.values(STATUS))
+                .set(START_TIME, MySQLDSL.values(START_TIME))
+                .set(END_TIME, MySQLDSL.values(END_TIME))
+                .set(COST, MySQLDSL.values(COST))
+                .set(EXECUTE_COUNT, MySQLDSL.values(EXECUTE_COUNT))
+                .execute()
         }
     }
 

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildStageDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildStageDao.kt
@@ -31,7 +31,7 @@ import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.option.StageControlOption
 import com.tencent.devops.common.pipeline.pojo.StagePauseCheck
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.process.Tables.T_PIPELINE_BUILD_STAGE
 import com.tencent.devops.model.process.tables.records.TPipelineBuildStageRecord
 import com.tencent.devops.process.engine.common.Timeout

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildSummaryDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildSummaryDao.kt
@@ -30,7 +30,7 @@ package com.tencent.devops.process.engine.dao
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ChannelCode
 import com.tencent.devops.common.pipeline.pojo.BuildNo
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.process.Tables.T_PIPELINE_BUILD_SUMMARY
 import com.tencent.devops.model.process.Tables.T_PIPELINE_INFO
 import com.tencent.devops.model.process.tables.records.TPipelineBuildSummaryRecord

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineContainerService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineContainerService.kt
@@ -48,7 +48,7 @@ import com.tencent.devops.common.pipeline.pojo.element.market.MarketBuildLessAto
 import com.tencent.devops.common.pipeline.pojo.element.matrix.MatrixStatusElement
 import com.tencent.devops.common.pipeline.utils.ModelUtils
 import com.tencent.devops.common.redis.RedisOperation
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.process.engine.common.VMUtils
 import com.tencent.devops.process.engine.context.MatrixBuildContext
 import com.tencent.devops.process.engine.control.VmOperateTaskGenerator

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineContainerService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineContainerService.kt
@@ -884,7 +884,9 @@ class PipelineContainerService @Autowired constructor(
 
             if (needAddCurrentBuildNo || needUpdateBuildNoRecord || context.currentBuildNo == null) {
                 PipelineBuildNoLock(redisOperation = redisOperation, pipelineId = context.pipelineId).use { lock ->
+                    context.watcher.start("${stage.id}.currentBuildNo_lock")
                     lock.lock()
+                    context.watcher.stop()
                     if (context.currentBuildNo == null) { // 兼容buildNo为空的情况
 
                         context.currentBuildNo = pipelineBuildSummaryDao.getBuildNo(

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeExtService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeExtService.kt
@@ -35,6 +35,7 @@ import com.tencent.devops.process.engine.pojo.BuildInfo
 import org.jooq.DSLContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class PipelineRuntimeExtService @Autowired constructor(
@@ -120,6 +121,7 @@ class PipelineRuntimeExtService @Autowired constructor(
                 dslContext = dslContext,
                 projectId = projectId,
                 buildId = buildInfo.buildId,
+                startTime = LocalDateTime.now(), // 设置startTime解决在按天查询时查不出来的问题
                 oldBuildStatus = buildInfo.status,
                 newBuildStatus = buildStatus
             )

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -61,40 +61,11 @@ import com.tencent.devops.common.pipeline.pojo.BuildParameters
 import com.tencent.devops.common.pipeline.pojo.element.agent.ManualReviewUserTaskElement
 import com.tencent.devops.common.pipeline.pojo.element.quality.QualityGateInElement
 import com.tencent.devops.common.pipeline.pojo.element.quality.QualityGateOutElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGitWebHookTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGithubWebHookTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGitlabWebHookTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeSVNWebHookTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeTGitWebHookTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.ManualTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.RemoteTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.TimerTriggerElement
-import com.tencent.devops.common.pipeline.pojo.element.trigger.enums.CodeType
 import com.tencent.devops.common.pipeline.pojo.time.BuildTimestampType
 import com.tencent.devops.common.pipeline.utils.SkipElementUtils
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.service.trace.TraceTag
 import com.tencent.devops.common.service.utils.MessageCodeUtil
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_EVENT_TYPE
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_ISSUE_IID
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_MR_ID
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_MR_MERGE_COMMIT_SHA
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_MR_NUMBER
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_MR_SOURCE_BRANCH
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_MR_URL
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_NOTE_ID
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_REVIEW_ID
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_GIT_WEBHOOK_TAG_NAME
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_WEBHOOK_REPO_ALIAS_NAME
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_WEBHOOK_REPO_AUTH_USER
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_WEBHOOK_REPO_NAME
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_WEBHOOK_REPO_TYPE
-import com.tencent.devops.common.webhook.pojo.code.BK_REPO_WEBHOOK_REPO_URL
-import com.tencent.devops.common.webhook.pojo.code.PIPELINE_WEBHOOK_BRANCH
-import com.tencent.devops.common.webhook.pojo.code.PIPELINE_WEBHOOK_COMMIT_MESSAGE
-import com.tencent.devops.common.webhook.pojo.code.PIPELINE_WEBHOOK_EVENT_TYPE
-import com.tencent.devops.common.webhook.pojo.code.PIPELINE_WEBHOOK_REVISION
-import com.tencent.devops.common.webhook.pojo.code.PIPELINE_WEBHOOK_TYPE
 import com.tencent.devops.common.websocket.enum.RefreshType
 import com.tencent.devops.model.process.tables.records.TPipelineBuildHistoryRecord
 import com.tencent.devops.model.process.tables.records.TPipelineBuildSummaryRecord
@@ -110,7 +81,6 @@ import com.tencent.devops.process.engine.common.BS_MANUAL_ACTION_PARAMS
 import com.tencent.devops.process.engine.common.BS_MANUAL_ACTION_SUGGEST
 import com.tencent.devops.process.engine.common.BS_MANUAL_ACTION_USERID
 import com.tencent.devops.process.engine.common.Timeout
-import com.tencent.devops.process.engine.control.lock.PipelineBuildHistoryLock
 import com.tencent.devops.process.engine.control.lock.PipelineVersionLock
 import com.tencent.devops.process.engine.dao.PipelineBuildDao
 import com.tencent.devops.process.engine.dao.PipelineBuildSummaryDao
@@ -124,7 +94,6 @@ import com.tencent.devops.process.engine.pojo.PipelineBuildStage
 import com.tencent.devops.process.engine.pojo.PipelineBuildStageControlOption
 import com.tencent.devops.process.engine.pojo.PipelineBuildTask
 import com.tencent.devops.process.engine.pojo.PipelineFilterParam
-import com.tencent.devops.process.engine.pojo.PipelineInfo
 import com.tencent.devops.process.engine.pojo.builds.CompleteTask
 import com.tencent.devops.process.engine.pojo.event.PipelineBuildAtomTaskEvent
 import com.tencent.devops.process.engine.pojo.event.PipelineBuildCancelEvent
@@ -136,7 +105,6 @@ import com.tencent.devops.process.engine.pojo.event.PipelineBuildWebSocketPushEv
 import com.tencent.devops.process.engine.pojo.event.PipelineContainerAgentHeartBeatEvent
 import com.tencent.devops.process.engine.service.record.PipelineBuildRecordService
 import com.tencent.devops.process.engine.service.record.TaskBuildRecordService
-import com.tencent.devops.process.engine.service.rule.PipelineRuleService
 import com.tencent.devops.process.engine.utils.ContainerUtils
 import com.tencent.devops.process.pojo.BuildBasicInfo
 import com.tencent.devops.process.pojo.BuildHistory
@@ -148,33 +116,24 @@ import com.tencent.devops.process.pojo.ReviewParam
 import com.tencent.devops.process.pojo.app.StartBuildContext
 import com.tencent.devops.process.pojo.code.WebhookInfo
 import com.tencent.devops.process.pojo.pipeline.PipelineLatestBuild
-import com.tencent.devops.process.pojo.pipeline.enums.PipelineRuleBusCodeEnum
 import com.tencent.devops.process.pojo.pipeline.record.BuildRecordContainer
 import com.tencent.devops.process.pojo.pipeline.record.BuildRecordContainer.Companion.addRecords
 import com.tencent.devops.process.pojo.pipeline.record.BuildRecordModel
 import com.tencent.devops.process.pojo.pipeline.record.BuildRecordStage
 import com.tencent.devops.process.pojo.pipeline.record.BuildRecordStage.Companion.addRecords
 import com.tencent.devops.process.pojo.pipeline.record.BuildRecordTask
-import com.tencent.devops.process.pojo.setting.PipelineRunLockType
-import com.tencent.devops.process.pojo.setting.PipelineSetting
 import com.tencent.devops.process.service.BuildVariableService
 import com.tencent.devops.process.service.StageTagService
 import com.tencent.devops.process.util.BuildMsgUtils
 import com.tencent.devops.process.utils.BUILD_NO
 import com.tencent.devops.process.utils.DependOnUtils
 import com.tencent.devops.process.utils.PIPELINE_BUILD_ID
-import com.tencent.devops.process.utils.PIPELINE_BUILD_MSG
 import com.tencent.devops.process.utils.PIPELINE_BUILD_NUM
-import com.tencent.devops.process.utils.PIPELINE_BUILD_NUM_ALIAS
 import com.tencent.devops.process.utils.PIPELINE_BUILD_REMARK
 import com.tencent.devops.process.utils.PIPELINE_BUILD_URL
 import com.tencent.devops.process.utils.PIPELINE_NAME
 import com.tencent.devops.process.utils.PIPELINE_RETRY_COUNT
 import com.tencent.devops.process.utils.PIPELINE_START_TASK_ID
-import com.tencent.devops.process.utils.PIPELINE_START_TYPE
-import com.tencent.devops.process.utils.PIPELINE_START_USER_ID
-import com.tencent.devops.process.utils.PIPELINE_START_USER_NAME
-import com.tencent.devops.process.utils.PIPELINE_VERSION
 import com.tencent.devops.process.utils.PipelineVarUtil
 import org.jooq.DSLContext
 import org.jooq.Result
@@ -218,7 +177,6 @@ class PipelineRuntimeService @Autowired constructor(
     private val recordModelDao: BuildRecordModelDao,
     private val buildVariableService: BuildVariableService,
     private val pipelineSettingService: PipelineSettingService,
-    private val pipelineRuleService: PipelineRuleService,
     private val modelCheckPlugin: ModelCheckPlugin,
     private val pipelineBuildRecordService: PipelineBuildRecordService,
     private val taskBuildRecordService: TaskBuildRecordService,
@@ -531,7 +489,7 @@ class PipelineRuntimeService @Autowired constructor(
                 },
                 webHookType = webhookType,
                 webhookInfo = webhookInfo?.let { self -> JsonUtil.to(self, object : TypeReference<WebhookInfo?>() {}) },
-                startType = getStartType(trigger, webhookType),
+                startType = StartType.transform(trigger, webhookType),
                 recommendVersion = recommendVersion,
                 retry = executeCount?.let { it > 1 } == true,
                 errorInfoList = errorInfo?.let { self ->
@@ -548,40 +506,6 @@ class PipelineRuntimeService @Autowired constructor(
                 concurrencyGroup = concurrencyGroup,
                 executeCount = executeCount
             )
-        }
-    }
-
-    private fun getStartType(trigger: String, webhookType: String?): String {
-        return when (trigger) {
-            StartType.MANUAL.name -> {
-                ManualTriggerElement.classType
-            }
-            StartType.TIME_TRIGGER.name -> {
-                TimerTriggerElement.classType
-            }
-            StartType.WEB_HOOK.name -> {
-                when (webhookType) {
-                    CodeType.SVN.name -> {
-                        CodeSVNWebHookTriggerElement.classType
-                    }
-                    CodeType.GIT.name -> {
-                        CodeGitWebHookTriggerElement.classType
-                    }
-                    CodeType.GITLAB.name -> {
-                        CodeGitlabWebHookTriggerElement.classType
-                    }
-                    CodeType.GITHUB.name -> {
-                        CodeGithubWebHookTriggerElement.classType
-                    }
-                    CodeType.TGIT.name -> {
-                        CodeTGitWebHookTriggerElement.classType
-                    }
-                    else -> RemoteTriggerElement.classType
-                }
-            }
-            else -> { // StartType.SERVICE.name,  StartType.PIPELINE.name, StartType.REMOTE.name
-                RemoteTriggerElement.classType
-            }
         }
     }
 
@@ -728,47 +652,24 @@ class PipelineRuntimeService @Autowired constructor(
     }
 
     fun startBuild(
-        pipelineInfo: PipelineInfo,
         fullModel: Model,
-        originStartParams: MutableList<BuildParameters>,
-        pipelineParamMap: MutableMap<String, BuildParameters>,
-        setting: PipelineSetting?,
-        buildId: String,
-        buildNo: Int? = null,
-        buildNumRule: String? = null,
-        acquire: Boolean? = false,
-        triggerReviewers: List<String>? = null
+        context: StartBuildContext,
+        pipelineParamMap: MutableMap<String, BuildParameters>
     ): String {
         val now = LocalDateTime.now()
         // 2019-12-16 产品 rerun 需求
-        val projectId = pipelineInfo.projectId
-        val pipelineId = pipelineInfo.pipelineId
-        val version = pipelineInfo.version
-        val startBuildStatus: BuildStatus = if (triggerReviewers.isNullOrEmpty()) {
-            // 默认都是排队状态
-            BuildStatus.QUEUE
-        } else {
-            BuildStatus.TRIGGER_REVIEWING
-        }
         val detailUrl = pipelineUrlBean.genBuildDetailUrl(
-            projectId, pipelineId, buildId, null, null, false
+            context.projectId, context.pipelineId, context.buildId, null, null, false
         )
-        val context = StartBuildContext.init(
-            projectId = projectId,
-            pipelineId = pipelineId,
-            buildId = buildId,
-            resourceVersion = version,
-            params = pipelineParamMap.values.associate { it.key to it.value.toString() }
-        )
-        buildLogPrinter.startLog(buildId, null, null, context.executeCount)
+        buildLogPrinter.startLog(context.buildId, null, null, context.executeCount)
 
         val defaultStageTagId by lazy { stageTagService.getDefaultStageTag().data?.id }
 
-        val lastTimeBuildTasks = pipelineTaskService.listByBuildId(projectId, buildId)
-        val lastTimeBuildContainers = pipelineContainerService.listByBuildId(projectId, buildId)
-        val lastTimeBuildStages = pipelineStageService.listStages(projectId, buildId)
+        val lastTimeBuildTasks = pipelineTaskService.listByBuildId(context.projectId, context.buildId)
+        val lastTimeBuildContainers = pipelineContainerService.listByBuildId(context.projectId, context.buildId)
+        val lastTimeBuildStages = pipelineStageService.listStages(context.projectId, context.buildId)
 
-        val buildHistoryRecord = pipelineBuildDao.getBuildInfo(dslContext, projectId, buildId)
+        val buildHistoryRecord = pipelineBuildDao.getBuildInfo(dslContext, context.projectId, context.buildId)
 
         // # 7983 由于container需要使用名称动态展示状态，Record需要特殊保存
         val buildTaskList = mutableListOf<PipelineBuildTask>()
@@ -783,7 +684,6 @@ class PipelineRuntimeService @Autowired constructor(
         val updateExistsStage: MutableList<PipelineBuildStage> = ArrayList(fullModel.stages.size)
         val updateExistsContainerWithDetail: MutableList<Pair<PipelineBuildContainer, Container>> = mutableListOf()
 
-        context.currentBuildNo = buildNo
 //        var buildNoType: BuildNoType? = null
         // --- 第1层循环：Stage遍历处理 ---
         var afterRetryStage = false
@@ -792,13 +692,13 @@ class PipelineRuntimeService @Autowired constructor(
 
             // #2318 如果是stage重试不是当前stage且当前stage已经是完成状态，或者该stage被禁用，则直接跳过
             if (context.needSkipWhenStageFailRetry(stage) || stage.stageControlOption?.enable == false) {
-                logger.info("[$buildId|EXECUTE|#${stage.id!!}|${stage.status}|NOT_EXECUTE_STAGE")
+                logger.info("[${context.buildId}|EXECUTE|#${stage.id!!}|${stage.status}|NOT_EXECUTE_STAGE")
                 context.containerSeq += stage.containers.size // Job跳过计数也需要增加
                 if (index == 0) {
                     stage.containers.forEach {
                         if (it is TriggerContainer) {
                             it.status = BuildStatus.RUNNING.name
-                            it.name = ContainerUtils.getQueuingWaitName(it.name, startBuildStatus)
+                            it.name = ContainerUtils.getQueuingWaitName(it.name, context.startBuildStatus)
                         }
                     }
                     stage.executeCount?.let { count -> stage.executeCount = count + 1 }
@@ -806,8 +706,12 @@ class PipelineRuntimeService @Autowired constructor(
                 // record表需要记录被跳过的记录
                 if (stage.stageControlOption?.enable == false) {
                     stageBuildRecords.addRecords(
-                        projectId, pipelineId, version, buildId, stage, context, index,
-                        BuildStatus.SKIP, containerBuildRecords, taskBuildRecords
+                        stage = stage,
+                        context = context,
+                        stageIndex = index,
+                        buildStatus = BuildStatus.SKIP,
+                        containerBuildRecords = containerBuildRecords,
+                        taskBuildRecords = taskBuildRecords
                     )
                 }
                 return@nextStage
@@ -818,21 +722,31 @@ class PipelineRuntimeService @Autowired constructor(
             stage.containers.forEach nextContainer@{ container ->
                 if (container is TriggerContainer) { // 寻找触发点
                     pipelineContainerService.setUpTriggerContainer(
-                        version, stage, container, context, startBuildStatus,
-                        stageBuildRecords, containerBuildRecords, taskBuildRecords
+                        stage = stage,
+                        container = container,
+                        context = context,
+                        stageBuildRecords = stageBuildRecords,
+                        containerBuildRecords = containerBuildRecords,
+                        taskBuildRecords = taskBuildRecords
                     )
                     context.containerSeq++
                     containerBuildRecords.addRecords(
-                        projectId, pipelineId, version, buildId, stage, container,
-                        context, null, taskBuildRecords
+                        stage = stage,
+                        container = container,
+                        context = context,
+                        buildStatus = null,
+                        taskBuildRecords = taskBuildRecords
                     )
                     return@nextContainer
                 } else if (container is NormalContainer) {
                     if (!ContainerUtils.isNormalContainerEnable(container)) {
                         context.containerSeq++
                         containerBuildRecords.addRecords(
-                            projectId, pipelineId, version, buildId, stage, container,
-                            context, BuildStatus.SKIP, taskBuildRecords
+                            stage = stage,
+                            container = container,
+                            context = context,
+                            buildStatus = BuildStatus.SKIP,
+                            taskBuildRecords = taskBuildRecords
                         )
                         return@nextContainer
                     }
@@ -840,8 +754,11 @@ class PipelineRuntimeService @Autowired constructor(
                     if (!ContainerUtils.isVMBuildContainerEnable(container)) {
                         context.containerSeq++
                         containerBuildRecords.addRecords(
-                            projectId, pipelineId, version, buildId, stage, container,
-                            context, BuildStatus.SKIP, taskBuildRecords
+                            stage = stage,
+                            container = container,
+                            context = context,
+                            buildStatus = BuildStatus.SKIP,
+                            taskBuildRecords = taskBuildRecords
                         )
                         return@nextContainer
                     }
@@ -865,7 +782,7 @@ class PipelineRuntimeService @Autowired constructor(
                         )
                     ) {
 
-                        logger.info("[$buildId|RETRY_SKIP_JOB|j(${container.id!!})|${container.name}")
+                        logger.info("[${context.buildId}|RETRY_SKIP_JOB|j(${container.id!!})|${container.name}")
                         context.containerSeq++
                         return@nextContainer
                     }
@@ -876,7 +793,7 @@ class PipelineRuntimeService @Autowired constructor(
                     finallyStage如果不是属于重试的Stage，则需要将所有状态重置，不允许跳过
                 */
                 if (context.isRetryFailedContainer(container = container, stage = stage)) {
-                    logger.info("[$buildId|RETRY_SKIP_SUCCESSFUL_JOB|j(${container.containerId})|${container.name}")
+                    logger.info("[${context.buildId}|RETRY_SKIP_SUC_JOB|j(${container.containerId})|${container.name}")
                     context.containerSeq++
                     return@nextContainer
                 }
@@ -889,9 +806,9 @@ class PipelineRuntimeService @Autowired constructor(
                     container.retryFreshMatrixOption()
                     pipelineContainerService.cleanContainersInMatrixGroup(
                         transactionContext = dslContext,
-                        projectId = projectId,
-                        pipelineId = pipelineId,
-                        buildId = buildId,
+                        projectId = context.projectId,
+                        pipelineId = context.pipelineId,
+                        buildId = context.buildId,
                         matrixGroupId = container.id!!
                     )
                     // 去掉要重试的矩阵内部数据
@@ -900,9 +817,6 @@ class PipelineRuntimeService @Autowired constructor(
                 }
                 // --- 第3层循环：Element遍历处理 ---
                 pipelineContainerService.prepareBuildContainerTasks(
-                    projectId = projectId,
-                    pipelineId = pipelineId,
-                    buildId = buildId,
                     container = container,
                     context = context,
                     stage = stage,
@@ -964,9 +878,9 @@ class PipelineRuntimeService @Autowired constructor(
                 stage.resetBuildOption(true)
                 buildStages.add(
                     PipelineBuildStage(
-                        projectId = projectId,
-                        pipelineId = pipelineId,
-                        buildId = buildId,
+                        projectId = context.projectId,
+                        pipelineId = context.pipelineId,
+                        buildId = context.buildId,
                         stageId = stage.id!!,
                         seq = index,
                         status = stageStatus,
@@ -978,248 +892,182 @@ class PipelineRuntimeService @Autowired constructor(
                 )
             }
         }
-        val lock = if (!buildNumRule.isNullOrBlank()) {
-            PipelineBuildHistoryLock(redisOperation, pipelineId)
-        } else null
-        try {
-            lock?.lock()
-            dslContext.transaction { configuration ->
-                val transactionContext = DSL.using(configuration)
-                // 保存参数 过滤掉不需要保存持久化的临时参数
-                pipelineParamMap[PIPELINE_BUILD_ID] = BuildParameters(PIPELINE_BUILD_ID, buildId, readOnly = true)
-                pipelineParamMap[PIPELINE_BUILD_URL] = BuildParameters(PIPELINE_BUILD_URL, detailUrl, readOnly = true)
-//                    .filter { it.valueType != BuildFormPropertyType.TEMPORARY }.toMutableList()
-                val bizId = MDC.get(TraceTag.BIZID)
-                if (!bizId.isNullOrBlank()) { // 保存链路信息
-                    pipelineParamMap[TraceTag.TRACE_HEADER_DEVOPS_BIZID] = BuildParameters(
-                        key = TraceTag.TRACE_HEADER_DEVOPS_BIZID, value = bizId
-                    )
+
+        pipelineParamMap[PIPELINE_BUILD_ID] = BuildParameters(PIPELINE_BUILD_ID, context.buildId, readOnly = true)
+        pipelineParamMap[PIPELINE_BUILD_URL] = BuildParameters(PIPELINE_BUILD_URL, detailUrl, readOnly = true)
+        // 链路
+        val bizId = MDC.get(TraceTag.BIZID)
+        if (!bizId.isNullOrBlank()) { // 保存链路信息
+            pipelineParamMap[TraceTag.TRACE_HEADER_DEVOPS_BIZID] = BuildParameters(
+                key = TraceTag.TRACE_HEADER_DEVOPS_BIZID, value = bizId
+            )
+        }
+        // 写入BuildNo
+        context.currentBuildNo?.let { bn ->
+            if (context.buildNoType != BuildNoType.SUCCESS_BUILD_INCREMENT && context.actionType == ActionType.START) {
+                val buildParameters = BuildParameters(key = BUILD_NO, value = bn, readOnly = true)
+                pipelineParamMap[BUILD_NO] = buildParameters
+                context.buildParameters.add(pipelineParamMap[BUILD_NO]!!)
+            }
+        }
+
+        pipelineParamMap[PIPELINE_START_TASK_ID] =
+            BuildParameters(PIPELINE_START_TASK_ID, context.firstTaskId, readOnly = true)
+
+        if (buildHistoryRecord != null) {
+            if (context.actionType.isRetry() && context.retryStartTaskId.isNullOrBlank()) {
+                // 完整重试,重置启动时间
+                buildHistoryRecord.startTime = now
+            }
+            buildHistoryRecord.endTime = null
+            buildHistoryRecord.queueTime = now // for EPC
+            buildHistoryRecord.status = context.startBuildStatus.ordinal
+            // 重试时启动参数只需要刷新执行次数
+            buildHistoryRecord.buildParameters = buildHistoryRecord.buildParameters?.let { self ->
+                val retryCount = context.executeCount - 1
+                val list = JsonUtil.getObjectMapper().readValue(self) as MutableList<BuildParameters>
+                list.find { it.key == PIPELINE_RETRY_COUNT }?.let { param ->
+                    param.value = retryCount
+                } ?: run {
+                    list.add(BuildParameters(key = PIPELINE_RETRY_COUNT, value = retryCount)) // 不加readOnly，历史原因
                 }
-                // 写入BuildNo
-                context.currentBuildNo?.let { bn ->
-                    if (
-                        context.buildNoType != BuildNoType.SUCCESS_BUILD_INCREMENT &&
-                        context.actionType == ActionType.START
-                    ) {
-                        val buildParameters = BuildParameters(key = BUILD_NO, value = bn, readOnly = true)
-                        pipelineParamMap[BUILD_NO] = buildParameters
-                        originStartParams.add(buildParameters)
-                    }
-                }
-                pipelineParamMap[PIPELINE_START_TASK_ID] =
-                    BuildParameters(PIPELINE_START_TASK_ID, context.firstTaskId, readOnly = true)
+                JsonUtil.toJson(list)
+            }
+        }
 
-                val buildNum: Int
-                if (buildHistoryRecord != null) {
-                    if (context.actionType.isRetry() && context.retryStartTaskId.isNullOrBlank()) {
-                        // 完整重试,重置启动时间
-                        buildHistoryRecord.startTime = now
-                    }
-                    buildHistoryRecord.endTime = null
-                    buildHistoryRecord.queueTime = now // for EPC
-                    buildHistoryRecord.status = startBuildStatus.ordinal
-                    // 重试时启动参数只需要刷新执行次数
-                    buildHistoryRecord.buildParameters = buildHistoryRecord.buildParameters?.let { self ->
-                        val retryCount = context.executeCount - 1
-                        val list = JsonUtil.getObjectMapper().readValue(self) as MutableList<BuildParameters>
-                        list.find { it.key == PIPELINE_RETRY_COUNT }?.let { param ->
-                            param.value = retryCount
-                        } ?: run {
-                            list.add(
-                                BuildParameters(
-                                    key = PIPELINE_RETRY_COUNT,
-                                    value = retryCount
-                                )
-                            )
-                        }
-                        JsonUtil.toJson(list)
-                    }
-                    transactionContext.batchStore(buildHistoryRecord).execute()
-                    // 重置状态和人
-                    buildDetailDao.update(
-                        dslContext = transactionContext,
-                        projectId = projectId,
-                        buildId = buildId,
-                        model = JsonUtil.toJson(fullModel, formatted = false),
-                        buildStatus = startBuildStatus,
-                        cancelUser = ""
-                    )
-                    buildNum = buildHistoryRecord.buildNum
-                    pipelineParamMap[PIPELINE_BUILD_NUM] = BuildParameters(
-                        key = PIPELINE_BUILD_NUM, value = buildNum.toString(), readOnly = true
-                    )
-                } else { // 创建构建记录
-                    val buildNumAlias = if (!buildNumRule.isNullOrBlank()) {
-                        val parsedValue = pipelineRuleService.parsePipelineRule(
-                            projectId = projectId,
-                            pipelineId = pipelineId,
-                            buildId = buildId,
-                            busCode = PipelineRuleBusCodeEnum.BUILD_NUM.name,
-                            ruleStr = buildNumRule
-                        )
-                        if (parsedValue.length > 256) parsedValue.substring(0, 256) else parsedValue
-                    } else null
-                    // 写自定义构建号信息
-                    if (!buildNumAlias.isNullOrBlank()) {
-                        pipelineParamMap[PIPELINE_BUILD_NUM_ALIAS] = BuildParameters(
-                            key = PIPELINE_BUILD_NUM_ALIAS, value = buildNumAlias, readOnly = true
-                        )
-                    }
-                    // 构建号递增
-                    buildNum = pipelineBuildSummaryDao.updateBuildNum(
-                        dslContext = transactionContext,
-                        projectId = projectId,
-                        pipelineId = pipelineId,
-                        buildNumAlias = buildNumAlias
-                    )
-                    pipelineParamMap[PIPELINE_BUILD_NUM] = BuildParameters(
-                        key = PIPELINE_BUILD_NUM, value = buildNum.toString(), readOnly = true
-                    )
-
-                    // 优化并发组逻辑，只在GROUP_LOCK时才保存进history表
-                    val concurrencyGroup = if (setting?.runLockType == PipelineRunLockType.GROUP_LOCK) {
-                        setting.concurrencyGroup
-                    } else null
-                    val pipelineVersionLock = PipelineVersionLock(redisOperation, pipelineId, version)
-                    try {
-                        pipelineVersionLock.lock()
-                        pipelineBuildDao.create(
-                            dslContext = transactionContext,
-                            projectId = projectId,
-                            pipelineId = pipelineId,
-                            buildId = buildId,
-                            version = context.variables[PIPELINE_VERSION].toString().toInt(),
-                            buildNum = buildNum,
-                            trigger = context.startType.name,
-                            status = startBuildStatus,
-                            startUser = context.userId,
-                            triggerUser = context.triggerUser,
-                            taskCount = context.taskCount,
-                            firstTaskId = context.firstTaskId,
-                            channelCode = context.channelCode,
-                            parentBuildId = context.parentBuildId,
-                            parentTaskId = context.parentTaskId,
-                            buildParameters = originStartParams,
-                            webhookType = context.variables[PIPELINE_WEBHOOK_TYPE],
-                            webhookInfo = getWebhookInfo(context.variables),
-                            buildMsg = getBuildMsg(context.variables[PIPELINE_BUILD_MSG]),
-                            buildNumAlias = buildNumAlias,
-                            concurrencyGroup = concurrencyGroup
-                        )
-                        // 查询流水线版本记录
-                        val pipelineVersionInfo = pipelineResVersionDao.getPipelineVersionSimple(
-                            dslContext = transactionContext,
-                            projectId = projectId,
-                            pipelineId = pipelineId,
-                            version = version
-                        )
-                        val referFlag = pipelineVersionInfo?.referFlag ?: true
-                        var referCount = pipelineVersionInfo?.referCount
-                        referCount = if (referCount == null) {
-                            // 兼容老数据缺少关联构建记录的情况，全量统计关联数据数量
-                            pipelineBuildDao.countBuildNumByVersion(
-                                dslContext = transactionContext,
-                                projectId = projectId,
-                                pipelineId = pipelineId,
-                                version = version
-                            )
-                        } else {
-                            referCount + 1
-                        }
-                        // 更新流水线版本关联构建记录信息
-                        pipelineResVersionDao.updatePipelineVersionReferInfo(
-                            dslContext = transactionContext,
-                            projectId = projectId,
-                            pipelineId = pipelineId,
-                            version = version,
-                            referCount = referCount,
-                            referFlag = referFlag
-                        )
-                    } finally {
-                        pipelineVersionLock.unlock()
-                    }
-
-                    // detail记录,未正式启动，先排队状态
-                    buildDetailDao.create(
-                        dslContext = transactionContext,
-                        projectId = pipelineInfo.projectId,
-                        buildId = buildId,
-                        startUser = context.userId,
-                        startType = context.startType,
-                        buildNum = buildNum,
-                        model = JsonUtil.toJson(fullModel, formatted = false),
-                        buildStatus = startBuildStatus
-                    )
-
-                    // 设置流水线每日构建次数
-                    pipelineSettingService.setCurrentDayBuildCount(
-                        transactionContext = transactionContext,
-                        projectId = pipelineInfo.projectId,
-                        pipelineId = pipelineId
-                    )
-                }
-
-                buildVariableService.batchSetVariable(
+        dslContext.transaction { configuration ->
+            val transactionContext = DSL.using(configuration)
+            if (buildHistoryRecord != null) {
+                transactionContext.batchStore(buildHistoryRecord).execute()
+                // 重置状态和人
+                buildDetailDao.update(
                     dslContext = transactionContext,
-                    projectId = projectId,
-                    pipelineId = pipelineId,
-                    buildId = buildId,
-                    variables = pipelineParamMap
+                    projectId = context.projectId,
+                    buildId = context.buildId,
+                    model = JsonUtil.toJson(fullModel, formatted = false),
+                    buildStatus = context.startBuildStatus,
+                    cancelUser = ""
+                )
+                context.buildNum = buildHistoryRecord.buildNum
+            } else { // 创建构建记录
+                // 构建号递增
+                context.buildNum = pipelineBuildSummaryDao.updateBuildNum(
+                    dslContext = transactionContext,
+                    projectId = context.projectId,
+                    pipelineId = context.pipelineId,
+                    buildNumAlias = context.buildNumAlias
                 )
 
-                saveBuildRuntimeRecord(
+                pipelineBuildDao.create(dslContext = transactionContext, startBuildContext = context)
+
+                // detail记录,未正式启动，先排队状态
+                buildDetailDao.create(
+                    dslContext = transactionContext,
+                    projectId = context.projectId,
+                    buildId = context.buildId,
+                    startUser = context.userId,
+                    startType = context.startType,
+                    buildNum = context.buildNum,
+                    model = JsonUtil.toJson(fullModel, formatted = false),
+                    buildStatus = context.startBuildStatus
+                )
+
+                // 设置流水线每日构建次数
+                pipelineSettingService.setCurrentDayBuildCount(
                     transactionContext = transactionContext,
-                    context = context,
-                    startBuildStatus = startBuildStatus,
-                    buildNum = buildNum,
-                    resourceVersion = version,
-                    updateExistsStage = updateExistsStage,
-                    updateExistsContainer = updateExistsContainerWithDetail,
-                    updateExistsTask = updateExistsTask,
-                    buildStages = buildStages,
-                    buildContainers = buildContainersWithDetail,
-                    buildTaskList = buildTaskList,
-                    stageBuildRecords = stageBuildRecords,
-                    containerBuildRecords = containerBuildRecords,
-                    taskBuildRecords = taskBuildRecords
-                )
-                // 排队计数+1
-                pipelineBuildSummaryDao.updateQueueCount(
-                    dslContext = transactionContext,
-                    projectId = pipelineInfo.projectId,
-                    pipelineId = pipelineInfo.pipelineId,
-                    queueIncrement = 1
+                    projectId = context.projectId,
+                    pipelineId = context.pipelineId
                 )
             }
-        } finally {
-            lock?.unlock()
-        }
-        // 如果不需要触发审核则直接开始发送开始事件
-        if (startBuildStatus.isReadyToRun()) {
-            sendBuildStartEvent(
-                buildId = buildId,
-                pipelineId = pipelineInfo.pipelineId,
-                projectId = pipelineInfo.projectId,
-                context = context,
-                startBuildStatus = startBuildStatus
+
+            pipelineParamMap[PIPELINE_BUILD_NUM] = BuildParameters(
+                key = PIPELINE_BUILD_NUM, value = context.buildNum.toString(), readOnly = true
             )
-        } else if (triggerReviewers?.isNotEmpty() == true) {
+
+            buildVariableService.batchSetVariable(
+                dslContext = transactionContext,
+                projectId = context.projectId,
+                pipelineId = context.pipelineId,
+                buildId = context.buildId,
+                variables = pipelineParamMap
+            )
+
+            saveBuildRuntimeRecord(
+                transactionContext = transactionContext,
+                context = context,
+                startBuildStatus = context.startBuildStatus,
+                buildNum = context.buildNum,
+                resourceVersion = context.resourceVersion,
+                updateExistsStage = updateExistsStage,
+                updateExistsContainer = updateExistsContainerWithDetail,
+                updateExistsTask = updateExistsTask,
+                buildStages = buildStages,
+                buildContainers = buildContainersWithDetail,
+                buildTaskList = buildTaskList,
+                stageBuildRecords = stageBuildRecords,
+                containerBuildRecords = containerBuildRecords,
+                taskBuildRecords = taskBuildRecords
+            )
+            // 排队计数+1
+            pipelineBuildSummaryDao.updateQueueCount(
+                dslContext = transactionContext,
+                projectId = context.projectId,
+                pipelineId = context.pipelineId,
+                queueIncrement = 1
+            )
+        }
+
+        // 如果不需要触发审核则直接开始发送开始事件
+        if (context.startBuildStatus.isReadyToRun()) {
+            context.sendBuildStartEvent()
+        } else if (context.triggerReviewers?.isNotEmpty() == true) {
             prepareTriggerReview(
-                userId = context.variables[PIPELINE_START_USER_ID] ?: pipelineInfo.lastModifyUser,
-                triggerUser = context.variables[PIPELINE_START_USER_NAME] ?: pipelineInfo.lastModifyUser,
-                buildId = buildId,
-                pipelineId = pipelineId,
-                projectId = projectId,
-                triggerReviewers = triggerReviewers,
-                pipelineName = pipelineParamMap[PIPELINE_NAME]?.value?.toString() ?: pipelineId,
-                buildNum = pipelineParamMap[PIPELINE_BUILD_NUM]?.value?.toString() ?: "1"
+                userId = context.userId,
+                triggerUser = context.triggerUser,
+                buildId = context.buildId,
+                pipelineId = context.pipelineId,
+                projectId = context.projectId,
+                triggerReviewers = context.triggerReviewers!!,
+                pipelineName = pipelineParamMap[PIPELINE_NAME]?.value?.toString() ?: context.pipelineId,
+                buildNum = context.buildNum.toString()
             )
             buildLogPrinter.addYellowLine(
-                buildId = buildId, message = "Waiting for the review of $triggerReviewers",
+                buildId = context.buildId, message = "Waiting for the review of ${context.triggerReviewers}",
                 tag = TAG, jobId = JOB_ID, executeCount = 1
             )
         }
-        return buildId
+        return context.buildId
+    }
+
+    fun addVersionRef(projectId: String, pipelineId: String, resourceVersion: Int) {
+        PipelineVersionLock(redisOperation, pipelineId, resourceVersion).use { versionLock ->
+            versionLock.lock()
+            // 查询流水线版本记录
+            val pipelineVersionInfo = pipelineResVersionDao.getPipelineVersionSimple(
+                dslContext = dslContext,
+                projectId = projectId,
+                pipelineId = pipelineId,
+                version = resourceVersion
+            )
+            val referFlag = pipelineVersionInfo?.referFlag ?: true
+            val referCount = pipelineVersionInfo?.referCount?.let { self -> self + 1 }
+                ?: pipelineBuildDao.countBuildNumByVersion( // 兼容老数据缺少关联构建记录的情况，全量统计关联数据数量
+                    dslContext = dslContext,
+                    projectId = projectId,
+                    pipelineId = pipelineId,
+                    version = resourceVersion
+                )
+
+            // 更新流水线版本关联构建记录信息
+            pipelineResVersionDao.updatePipelineVersionReferInfo(
+                dslContext = dslContext,
+                projectId = projectId,
+                pipelineId = pipelineId,
+                version = resourceVersion,
+                referCount = referCount,
+                referFlag = referFlag
+            )
+        }
     }
 
     private fun saveBuildRuntimeRecord(
@@ -1387,13 +1235,17 @@ class PipelineRuntimeService @Autowired constructor(
                 buildId = buildId, message = "Approved by user($userId)",
                 tag = TAG, jobId = JOB_ID, executeCount = 1
             )
-            sendBuildStartEvent(
-                buildId = buildId,
-                pipelineId = pipelineId,
+            StartBuildContext.init(
                 projectId = projectId,
-                context = StartBuildContext.init(projectId, pipelineId, buildId, resourceVersion, variables),
-                startBuildStatus = newBuildStatus
-            )
+                pipelineId = pipelineId,
+                buildId = buildId,
+                resourceVersion = resourceVersion,
+                params = variables,
+                startBuildStatus = newBuildStatus,
+                buildParameters = mutableListOf()
+            ).apply {
+                buildNoType = null // 该字段是需要遍历Model获得，不过在审核阶段为null，目前不影响功能逻辑。
+            }.sendBuildStartEvent()
         }
     }
 
@@ -1445,38 +1297,32 @@ class PipelineRuntimeService @Autowired constructor(
     ) = pipelineTriggerReviewDao.getTriggerReviewers(dslContext, projectId, pipelineId, buildId)
         ?.contains(userId) == true
 
-    private fun sendBuildStartEvent(
-        buildId: String,
-        pipelineId: String,
-        projectId: String,
-        context: StartBuildContext,
-        startBuildStatus: BuildStatus
-    ) {
+    private fun StartBuildContext.sendBuildStartEvent() {
         pipelineEventDispatcher.dispatch(
             PipelineBuildStartEvent(
                 source = "startBuild",
                 projectId = projectId,
                 pipelineId = pipelineId,
-                userId = context.userId,
+                userId = userId,
                 buildId = buildId,
-                taskId = context.firstTaskId,
+                taskId = firstTaskId,
                 status = startBuildStatus,
-                actionType = context.actionType,
-                buildNoType = context.buildNoType
+                actionType = actionType,
+                buildNoType = buildNoType // 该字段是需要遍历Model‘获得，不过在审核阶段为null，不影响功能逻辑。
             ), // 监控事件
             PipelineBuildMonitorEvent(
                 source = "startBuild",
                 projectId = projectId,
                 pipelineId = pipelineId,
-                userId = context.userId,
+                userId = userId,
                 buildId = buildId,
-                executeCount = context.executeCount
+                executeCount = executeCount
             ), // #3400 点启动处于DETAIL界面，以操作人视角，没有刷历史列表的必要，在buildStart真正启动时也会有HISTORY，减少负载
             PipelineBuildWebSocketPushEvent(
                 source = "startBuild",
                 projectId = projectId,
                 pipelineId = pipelineId,
-                userId = context.userId,
+                userId = userId,
                 buildId = buildId,
                 // 刷新历史列表和详情页面
                 refreshTypes = RefreshType.DETAIL.binary
@@ -1485,10 +1331,10 @@ class PipelineRuntimeService @Autowired constructor(
                 source = "startQueue",
                 projectId = projectId,
                 pipelineId = pipelineId,
-                userId = context.userId,
+                userId = userId,
                 buildId = buildId,
-                actionType = context.actionType,
-                triggerType = context.startType.name
+                actionType = actionType,
+                triggerType = startType.name
             )
         )
     }
@@ -1546,46 +1392,6 @@ class PipelineRuntimeService @Autowired constructor(
                 stageId = null
             )
         )
-    }
-
-    private fun getWebhookInfo(params: Map<String, Any>): String? {
-        if (params[PIPELINE_START_TYPE] != StartType.WEB_HOOK.name) {
-            return null
-        }
-        return JsonUtil.toJson(
-            bean = WebhookInfo(
-                codeType = params[BK_REPO_WEBHOOK_REPO_TYPE]?.toString(),
-                nameWithNamespace = params[BK_REPO_WEBHOOK_REPO_NAME]?.toString(),
-                webhookMessage = params[PIPELINE_WEBHOOK_COMMIT_MESSAGE]?.toString(),
-                webhookRepoUrl = params[BK_REPO_WEBHOOK_REPO_URL]?.toString(),
-                webhookType = params[PIPELINE_WEBHOOK_TYPE]?.toString(),
-                webhookBranch = params[PIPELINE_WEBHOOK_BRANCH]?.toString(),
-                webhookAliasName = params[BK_REPO_WEBHOOK_REPO_ALIAS_NAME]?.toString(),
-                // GIT事件分为MR和MR accept,但是PIPELINE_WEBHOOK_EVENT_TYPE值只有MR
-                webhookEventType = if (params[PIPELINE_WEBHOOK_TYPE] == CodeType.GIT.name) {
-                    params[BK_REPO_GIT_WEBHOOK_EVENT_TYPE]?.toString()
-                } else {
-                    params[PIPELINE_WEBHOOK_EVENT_TYPE]?.toString()
-                },
-                refId = params[PIPELINE_WEBHOOK_REVISION]?.toString(),
-                webhookCommitId = params[PIPELINE_WEBHOOK_REVISION] as String?,
-                webhookMergeCommitSha = params[BK_REPO_GIT_WEBHOOK_MR_MERGE_COMMIT_SHA]?.toString(),
-                webhookSourceBranch = params[BK_REPO_GIT_WEBHOOK_MR_SOURCE_BRANCH]?.toString(),
-                mrId = params[BK_REPO_GIT_WEBHOOK_MR_ID]?.toString(),
-                mrIid = params[BK_REPO_GIT_WEBHOOK_MR_NUMBER]?.toString(),
-                mrUrl = params[BK_REPO_GIT_WEBHOOK_MR_URL]?.toString(),
-                repoAuthUser = params[BK_REPO_WEBHOOK_REPO_AUTH_USER]?.toString(),
-                tagName = params[BK_REPO_GIT_WEBHOOK_TAG_NAME]?.toString(),
-                issueIid = params[BK_REPO_GIT_WEBHOOK_ISSUE_IID]?.toString(),
-                noteId = params[BK_REPO_GIT_WEBHOOK_NOTE_ID]?.toString(),
-                reviewId = params[BK_REPO_GIT_WEBHOOK_REVIEW_ID]?.toString()
-            ),
-            formatted = false
-        )
-    }
-
-    private fun getBuildMsg(buildMsg: String?): String? {
-        return buildMsg?.substring(0, buildMsg.length.coerceAtMost(255))
     }
 
     /**

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineSettingService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineSettingService.kt
@@ -88,14 +88,14 @@ class PipelineSettingService @Autowired constructor(
         }
     }
 
-    fun setCurrentDayBuildCount(transactionContext: DSLContext, projectId: String, pipelineId: String): Int {
+    fun setCurrentDayBuildCount(transactionContext: DSLContext?, projectId: String, pipelineId: String): Int {
         val currentDayStr = DateTimeUtil.formatDate(Date(), DateTimeUtil.YYYY_MM_DD)
         val currentDayBuildCountKey = getCurrentDayBuildCountKey(pipelineId, currentDayStr)
         // 判断缓存中是否有值，没有值则从db中实时查
         if (!redisOperation.hasKey(currentDayBuildCountKey)) {
             logger.info("setCurrentDayBuildCount $currentDayBuildCountKey is not exist!")
             getCurrentDayBuildCountFromDb(
-                transactionContext = transactionContext,
+                transactionContext = transactionContext ?: dslContext,
                 projectId = projectId,
                 currentDayStr = currentDayStr,
                 pipelineId = pipelineId

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineStageService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineStageService.kt
@@ -39,7 +39,7 @@ import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ManualReviewAction
 import com.tencent.devops.common.pipeline.pojo.StagePauseCheck
 import com.tencent.devops.common.pipeline.pojo.StageReviewRequest
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.common.websocket.enum.RefreshType
 import com.tencent.devops.process.engine.common.BS_MANUAL_START_STAGE
 import com.tencent.devops.process.engine.common.BS_QUALITY_ABORT_STAGE

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineStageService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineStageService.kt
@@ -39,6 +39,7 @@ import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ManualReviewAction
 import com.tencent.devops.common.pipeline.pojo.StagePauseCheck
 import com.tencent.devops.common.pipeline.pojo.StageReviewRequest
+import com.tencent.devops.common.service.utils.JooqUtils
 import com.tencent.devops.common.websocket.enum.RefreshType
 import com.tencent.devops.process.engine.common.BS_MANUAL_START_STAGE
 import com.tencent.devops.process.engine.common.BS_QUALITY_ABORT_STAGE
@@ -110,11 +111,13 @@ class PipelineStageService @Autowired constructor(
         checkOut: StagePauseCheck?
     ) {
         logger.info("[$buildId]|updateStageStatus|status=$buildStatus|stageId=$stageId")
-        pipelineBuildStageDao.updateStatus(
-            dslContext = dslContext, projectId = projectId, buildId = buildId,
-            stageId = stageId, buildStatus = buildStatus,
-            checkIn = checkIn, checkOut = checkOut
-        )
+        JooqUtils.retryWhenDeadLock {
+            pipelineBuildStageDao.updateStatus(
+                dslContext = dslContext, projectId = projectId, buildId = buildId,
+                stageId = stageId, buildStatus = buildStatus,
+                checkIn = checkIn, checkOut = checkOut
+            )
+        }
     }
 
     fun listStages(projectId: String, buildId: String): List<PipelineBuildStage> {
@@ -122,11 +125,15 @@ class PipelineStageService @Autowired constructor(
     }
 
     fun batchSave(transactionContext: DSLContext?, stageList: Collection<PipelineBuildStage>) {
-        return pipelineBuildStageDao.batchSave(transactionContext ?: dslContext, stageList)
+        return JooqUtils.retryWhenDeadLock {
+            pipelineBuildStageDao.batchSave(transactionContext ?: dslContext, stageList)
+        }
     }
 
     fun batchUpdate(transactionContext: DSLContext?, stageList: Collection<PipelineBuildStage>) {
-        return pipelineBuildStageDao.batchUpdate(transactionContext ?: dslContext, stageList)
+        return JooqUtils.retryWhenDeadLock {
+            pipelineBuildStageDao.batchUpdate(transactionContext ?: dslContext, stageList)
+        }
     }
 
     fun deletePipelineBuildStages(transactionContext: DSLContext?, projectId: String, pipelineId: String) {
@@ -146,17 +153,19 @@ class PipelineStageService @Autowired constructor(
                 stageId = stageId,
                 executeCount = executeCount
             )
-            dslContext.transaction { configuration ->
-                val context = DSL.using(configuration)
-                pipelineBuildStageDao.updateStatus(
-                    dslContext = context, projectId = projectId, buildId = buildId,
-                    stageId = stageId, buildStatus = BuildStatus.SKIP,
-                    controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
-                )
+            JooqUtils.retryWhenDeadLock {
+                dslContext.transaction { configuration ->
+                    val context = DSL.using(configuration)
+                    pipelineBuildStageDao.updateStatus(
+                        dslContext = context, projectId = projectId, buildId = buildId,
+                        stageId = stageId, buildStatus = BuildStatus.SKIP,
+                        controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
+                    )
 
-                pipelineBuildDao.updateBuildStageStatus(
-                    dslContext = context, projectId = projectId, buildId = buildId, stageStatus = allStageStatus
-                )
+                    pipelineBuildDao.updateBuildStageStatus(
+                        dslContext = context, projectId = projectId, buildId = buildId, stageStatus = allStageStatus
+                    )
+                }
             }
             pipelineEventDispatcher.dispatch(
                 PipelineBuildWebSocketPushEvent(
@@ -175,21 +184,23 @@ class PipelineStageService @Autowired constructor(
                 controlOption = controlOption!!, inOrOut = inOrOut,
                 checkIn = checkIn, checkOut = checkOut
             )
-            dslContext.transaction { configuration ->
-                val context = DSL.using(configuration)
-                pipelineBuildStageDao.updateStatus(
-                    dslContext = context, projectId = projectId, buildId = buildId,
-                    stageId = stageId, controlOption = controlOption!!,
-                    // #5246 所有质量红线检查都不影响stage原构建状态
-                    buildStatus = null, initStartTime = true,
-                    checkIn = checkIn, checkOut = checkOut
-                )
-                pipelineBuildDao.updateBuildStageStatus(
-                    dslContext = context,
-                    projectId = projectId,
-                    buildId = buildId,
-                    stageStatus = allStageStatus
-                )
+            JooqUtils.retryWhenDeadLock {
+                dslContext.transaction { configuration ->
+                    val context = DSL.using(configuration)
+                    pipelineBuildStageDao.updateStatus(
+                        dslContext = context, projectId = projectId, buildId = buildId,
+                        stageId = stageId, controlOption = controlOption!!,
+                        // #5246 所有质量红线检查都不影响stage原构建状态
+                        buildStatus = null, initStartTime = true,
+                        checkIn = checkIn, checkOut = checkOut
+                    )
+                    pipelineBuildDao.updateBuildStageStatus(
+                        dslContext = context,
+                        projectId = projectId,
+                        buildId = buildId,
+                        stageStatus = allStageStatus
+                    )
+                }
             }
             pipelineEventDispatcher.dispatch(
                 PipelineBuildWebSocketPushEvent(
@@ -218,25 +229,28 @@ class PipelineStageService @Autowired constructor(
                 checkIn = checkIn,
                 checkOut = checkOut
             )
-            dslContext.transaction { configuration ->
-                val context = DSL.using(configuration)
-                pipelineBuildStageDao.updateStatus(
-                    dslContext = context, projectId = projectId, buildId = buildId,
-                    stageId = stageId, buildStatus = BuildStatus.PAUSE,
-                    controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
-                )
-                pipelineBuildDao.updateStatus(
-                    dslContext = context, buildId = buildId, projectId = projectId,
-                    oldBuildStatus = BuildStatus.RUNNING, newBuildStatus = BuildStatus.STAGE_SUCCESS
-                )
-                pipelineBuildDao.updateBuildStageStatus(
-                    dslContext = context, projectId = projectId, buildId = buildId, stageStatus = allStageStatus
-                )
-                // 被暂停的流水线不占构建队列，在执行数-1
-                pipelineBuildSummaryDao.updateRunningCount(
-                    dslContext = context, projectId = projectId, pipelineId = pipelineId,
-                    buildId = buildId, runningIncrement = -1
-                )
+
+            JooqUtils.retryWhenDeadLock {
+                dslContext.transaction { configuration ->
+                    val context = DSL.using(configuration)
+                    pipelineBuildStageDao.updateStatus(
+                        dslContext = context, projectId = projectId, buildId = buildId,
+                        stageId = stageId, buildStatus = BuildStatus.PAUSE,
+                        controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
+                    )
+                    pipelineBuildDao.updateStatus(
+                        dslContext = context, buildId = buildId, projectId = projectId,
+                        oldBuildStatus = BuildStatus.RUNNING, newBuildStatus = BuildStatus.STAGE_SUCCESS
+                    )
+                    pipelineBuildDao.updateBuildStageStatus(
+                        dslContext = context, projectId = projectId, buildId = buildId, stageStatus = allStageStatus
+                    )
+                    // 被暂停的流水线不占构建队列，在执行数-1
+                    pipelineBuildSummaryDao.updateRunningCount(
+                        dslContext = context, projectId = projectId, pipelineId = pipelineId,
+                        buildId = buildId, runningIncrement = -1
+                    )
+                }
             }
 
             // #3400 点Stage启动时处于DETAIL界面，以操作人视角，没有刷历史列表的必要
@@ -261,12 +275,14 @@ class PipelineStageService @Autowired constructor(
                 controlOption = controlOption!!,
                 checkIn = checkIn, checkOut = checkOut
             )
-            // #4531 stage先保持暂停，如果没有其他需要审核的审核组则可以启动stage，否则直接返回
-            pipelineBuildStageDao.updateStatus(
-                dslContext = dslContext, projectId = projectId, buildId = buildId,
-                stageId = stageId, buildStatus = BuildStatus.PAUSE,
-                controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
-            )
+            JooqUtils.retryWhenDeadLock {
+                // #4531 stage先保持暂停，如果没有其他需要审核的审核组则可以启动stage，否则直接返回
+                pipelineBuildStageDao.updateStatus(
+                    dslContext = dslContext, projectId = projectId, buildId = buildId,
+                    stageId = stageId, buildStatus = BuildStatus.PAUSE,
+                    controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
+                )
+            }
             // 如果还有待审核的审核组，则直接通知并返回
             if (checkIn?.groupToReview() != null) {
                 val variables = buildVariableService.getAllVariable(projectId, pipelineId, buildId)
@@ -283,24 +299,26 @@ class PipelineStageService @Autowired constructor(
                     stageId = stageId, executeCount = executeCount,
                     controlOption = controlOption!!, checkIn = checkIn, checkOut = checkOut
                 )
-                dslContext.transaction { configuration ->
-                    val context = DSL.using(configuration)
-                    pipelineBuildStageDao.updateStatus(
-                        dslContext = context, projectId = projectId, buildId = buildId, stageId = stageId,
-                        buildStatus = BuildStatus.QUEUE,
-                        controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
-                    )
-                    pipelineBuildDao.updateStatus(
-                        dslContext = context, buildId = buildId, projectId = projectId,
-                        oldBuildStatus = BuildStatus.STAGE_SUCCESS, newBuildStatus = BuildStatus.RUNNING
-                    )
-                    pipelineBuildDao.updateBuildStageStatus(
-                        dslContext = context, projectId = projectId, buildId = buildId, stageStatus = allStageStatus
-                    )
-                    pipelineBuildSummaryDao.updateRunningCount(
-                        dslContext = context, projectId = projectId, pipelineId = pipelineId,
-                        buildId = buildId, runningIncrement = 1
-                    )
+                JooqUtils.retryWhenDeadLock {
+                    dslContext.transaction { configuration ->
+                        val context = DSL.using(configuration)
+                        pipelineBuildStageDao.updateStatus(
+                            dslContext = context, projectId = projectId, buildId = buildId, stageId = stageId,
+                            buildStatus = BuildStatus.QUEUE,
+                            controlOption = controlOption, checkIn = checkIn, checkOut = checkOut
+                        )
+                        pipelineBuildDao.updateStatus(
+                            dslContext = context, buildId = buildId, projectId = projectId,
+                            oldBuildStatus = BuildStatus.STAGE_SUCCESS, newBuildStatus = BuildStatus.RUNNING
+                        )
+                        pipelineBuildDao.updateBuildStageStatus(
+                            dslContext = context, projectId = projectId, buildId = buildId, stageStatus = allStageStatus
+                        )
+                        pipelineBuildSummaryDao.updateRunningCount(
+                            dslContext = context, projectId = projectId, pipelineId = pipelineId,
+                            buildId = buildId, runningIncrement = 1
+                        )
+                    }
                 }
                 pipelineEventDispatcher.dispatch(
                     PipelineBuildStageEvent(
@@ -393,23 +411,25 @@ class PipelineStageService @Autowired constructor(
                 checkIn = checkIn, checkOut = checkOut
             )
 
-            dslContext.transaction { configuration ->
-                val context = DSL.using(configuration)
-                pipelineBuildStageDao.updateStatus(
-                    dslContext = context,
-                    projectId = projectId,
-                    buildId = buildId, stageId = stageId, buildStatus = BuildStatus.STAGE_SUCCESS,
-                    checkIn = checkIn, checkOut = checkOut
-                )
-                pipelineBuildDao.updateStatus(
-                    dslContext = context, buildId = buildId, projectId = projectId,
-                    oldBuildStatus = BuildStatus.STAGE_SUCCESS, newBuildStatus = BuildStatus.RUNNING
-                )
-                // #4255 stage审核超时恢复运行状态需要将运行状态+1，即使直接结束也会在finish阶段减回来
-                pipelineBuildSummaryDao.updateRunningCount(
-                    dslContext = context, projectId = projectId, pipelineId = pipelineId,
-                    buildId = buildId, runningIncrement = 1
-                )
+            JooqUtils.retryWhenDeadLock {
+                dslContext.transaction { configuration ->
+                    val context = DSL.using(configuration)
+                    pipelineBuildStageDao.updateStatus(
+                        dslContext = context,
+                        projectId = projectId,
+                        buildId = buildId, stageId = stageId, buildStatus = BuildStatus.STAGE_SUCCESS,
+                        checkIn = checkIn, checkOut = checkOut
+                    )
+                    pipelineBuildDao.updateStatus(
+                        dslContext = context, buildId = buildId, projectId = projectId,
+                        oldBuildStatus = BuildStatus.STAGE_SUCCESS, newBuildStatus = BuildStatus.RUNNING
+                    )
+                    // #4255 stage审核超时恢复运行状态需要将运行状态+1，即使直接结束也会在finish阶段减回来
+                    pipelineBuildSummaryDao.updateRunningCount(
+                        dslContext = context, projectId = projectId, pipelineId = pipelineId,
+                        buildId = buildId, runningIncrement = 1
+                    )
+                }
             }
             // #3138 Stage Cancel 需要走finally Stage流程
             pipelineEventDispatcher.dispatch(
@@ -476,11 +496,13 @@ class PipelineStageService @Autowired constructor(
             } else {
                 Pair(BuildStatus.SUCCEED, BuildReviewType.QUALITY_CHECK_OUT)
             }
-            pipelineBuildStageDao.updateStatus(
-                dslContext = dslContext, projectId = projectId, buildId = buildId, stageId = stageId,
-                buildStatus = stageNextStatus, controlOption = controlOption,
-                checkIn = checkIn, checkOut = checkOut
-            )
+            JooqUtils.retryWhenDeadLock {
+                pipelineBuildStageDao.updateStatus(
+                    dslContext = dslContext, projectId = projectId, buildId = buildId, stageId = stageId,
+                    buildStatus = stageNextStatus, controlOption = controlOption,
+                    checkIn = checkIn, checkOut = checkOut
+                )
+            }
             val (source, actionType, reviewStatus) = if (qualityRequest.pass) {
                 check.status = BuildStatus.QUALITY_CHECK_PASS.name
                 Triple(BS_QUALITY_PASS_STAGE, ActionType.REFRESH, BuildStatus.REVIEW_PROCESSED)

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineTaskService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineTaskService.kt
@@ -42,7 +42,7 @@ import com.tencent.devops.common.pipeline.pojo.element.Element
 import com.tencent.devops.common.pipeline.pojo.element.ElementAdditionalOptions
 import com.tencent.devops.common.pipeline.utils.BuildStatusSwitcher
 import com.tencent.devops.common.redis.RedisOperation
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.process.tables.records.TPipelineInfoRecord
 import com.tencent.devops.model.process.tables.records.TPipelineModelTaskRecord
 import com.tencent.devops.process.engine.common.Timeout

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineTaskService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineTaskService.kt
@@ -42,6 +42,7 @@ import com.tencent.devops.common.pipeline.pojo.element.Element
 import com.tencent.devops.common.pipeline.pojo.element.ElementAdditionalOptions
 import com.tencent.devops.common.pipeline.utils.BuildStatusSwitcher
 import com.tencent.devops.common.redis.RedisOperation
+import com.tencent.devops.common.service.utils.JooqUtils
 import com.tencent.devops.model.process.tables.records.TPipelineInfoRecord
 import com.tencent.devops.model.process.tables.records.TPipelineModelTaskRecord
 import com.tencent.devops.process.engine.common.Timeout
@@ -193,7 +194,9 @@ class PipelineTaskService @Autowired constructor(
     }
 
     fun batchUpdate(transactionContext: DSLContext?, taskList: List<PipelineBuildTask>) {
-        return pipelineBuildTaskDao.batchUpdate(transactionContext ?: dslContext, taskList)
+        return JooqUtils.retryWhenDeadLock {
+            pipelineBuildTaskDao.batchUpdate(transactionContext ?: dslContext, taskList)
+        }
     }
 
     fun deletePipelineBuildTasks(transactionContext: DSLContext?, projectId: String, pipelineId: String) {
@@ -251,13 +254,15 @@ class PipelineTaskService @Autowired constructor(
     }
 
     fun updateTaskParamWithElement(projectId: String, buildId: String, taskId: String, newElement: Element) {
-        pipelineBuildTaskDao.updateTaskParam(
-            dslContext = dslContext,
-            projectId = projectId,
-            buildId = buildId,
-            taskId = taskId,
-            taskParam = JsonUtil.toJson(newElement, false)
-        )
+        JooqUtils.retryWhenDeadLock {
+            pipelineBuildTaskDao.updateTaskParam(
+                dslContext = dslContext,
+                projectId = projectId,
+                buildId = buildId,
+                taskId = taskId,
+                taskParam = JsonUtil.toJson(newElement, false)
+            )
+        }
     }
 
     fun updateTaskParam(
@@ -267,13 +272,15 @@ class PipelineTaskService @Autowired constructor(
         taskId: String,
         taskParam: String
     ): Int {
-        return pipelineBuildTaskDao.updateTaskParam(
-            dslContext = transactionContext ?: dslContext,
-            projectId = projectId,
-            buildId = buildId,
-            taskId = taskId,
-            taskParam = taskParam
-        )
+        return JooqUtils.retryWhenDeadLock {
+            pipelineBuildTaskDao.updateTaskParam(
+                dslContext = transactionContext ?: dslContext,
+                projectId = projectId,
+                buildId = buildId,
+                taskId = taskId,
+                taskParam = taskParam
+            )
+        }
     }
 
     fun listContainerBuildTasks(
@@ -307,14 +314,16 @@ class PipelineTaskService @Autowired constructor(
         subBuildId: String,
         subProjectId: String
     ): Int {
-        return pipelineBuildTaskDao.updateSubBuildId(
-            dslContext = dslContext,
-            projectId = projectId,
-            buildId = buildId,
-            taskId = taskId,
-            subBuildId = subBuildId,
-            subProjectId = subProjectId
-        )
+        return JooqUtils.retryWhenDeadLock {
+            pipelineBuildTaskDao.updateSubBuildId(
+                dslContext = dslContext,
+                projectId = projectId,
+                buildId = buildId,
+                taskId = taskId,
+                subBuildId = subBuildId,
+                subProjectId = subProjectId
+            )
+        }
     }
 
     fun setTaskErrorInfo(
@@ -326,15 +335,17 @@ class PipelineTaskService @Autowired constructor(
         errorCode: Int,
         errorMsg: String
     ) {
-        pipelineBuildTaskDao.setTaskErrorInfo(
-            dslContext = transactionContext ?: dslContext,
-            projectId = projectId,
-            buildId = buildId,
-            taskId = taskId,
-            errorType = errorType,
-            errorCode = errorCode,
-            errorMsg = errorMsg
-        )
+        JooqUtils.retryWhenDeadLock {
+            pipelineBuildTaskDao.setTaskErrorInfo(
+                dslContext = transactionContext ?: dslContext,
+                projectId = projectId,
+                buildId = buildId,
+                taskId = taskId,
+                errorType = errorType,
+                errorCode = errorCode,
+                errorMsg = errorMsg
+            )
+        }
     }
 
     fun updateTaskStatusInfo(userId: String? = null, task: PipelineBuildTask?, updateTaskInfo: UpdateTaskInfo) {
@@ -371,7 +382,10 @@ class PipelineTaskService @Autowired constructor(
                 }
             }
         }
-        pipelineBuildTaskDao.updateTaskInfo(dslContext = dslContext, updateTaskInfo = updateTaskInfo)
+
+        JooqUtils.retryWhenDeadLock {
+            pipelineBuildTaskDao.updateTaskInfo(dslContext = dslContext, updateTaskInfo = updateTaskInfo)
+        }
     }
 
     /**

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/BuildVariableService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/BuildVariableService.kt
@@ -198,6 +198,25 @@ class BuildVariableService @Autowired constructor(
         }
     }
 
+    /**
+     * 注意：该方法没做并发保护，仅用于在刚启动构建时使用，其他并发场景请使用[batchSetVariable]
+     */
+    fun startBuildBatchSaveWithoutThreadSafety(
+        dslContext: DSLContext,
+        projectId: String,
+        pipelineId: String,
+        buildId: String,
+        variables: Map<String, BuildParameters>
+    ) {
+        pipelineBuildVarDao.batchSave(
+            dslContext = dslContext,
+            projectId = projectId,
+            pipelineId = pipelineId,
+            buildId = buildId,
+            variables = variables.map { it.value }
+        )
+    }
+
     fun batchSetVariable(
         dslContext: DSLContext,
         projectId: String,

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/StageTagService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/StageTagService.kt
@@ -27,6 +27,8 @@
 
 package com.tencent.devops.process.service
 
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.LoadingCache
 import com.tencent.devops.common.api.constant.CommonMessageCode
 import com.tencent.devops.common.api.pojo.Result
 import com.tencent.devops.common.api.util.UUIDUtil
@@ -37,47 +39,67 @@ import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.time.Duration
 
+/**
+ * StageTag为后台插入，更新由平台OP控制，基本不会更新，只需要缓存在内存即可。即使出错也不影响正常逻辑，暂不引入redis
+ */
 @Service
 class StageTagService @Autowired constructor(
     private val dslContext: DSLContext,
     private val pipelineStageTagDao: PipelineStageTagDao
 ) {
-    private val logger = LoggerFactory.getLogger(StageTagService::class.java)
+    companion object {
+        private const val ALL = "ALL"
+        private const val DEFAULT = "DEFAULT"
+        private val logger = LoggerFactory.getLogger(StageTagService::class.java)
+    }
+
+    // StageTag为后台插入，更新由平台OP控制，不会经常更新，所以只需要缓存在内存即可。即使出错也不影响正常逻辑，暂不引入redis
+    private val defaultTagCache: LoadingCache<String, PipelineStageTag> = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofMinutes(1))
+        .maximumSize(1)
+        .build { pipelineStageTagDao.getDefaultStageTag(dslContext) }
+
+    // StageTag为后台插入，更新由平台OP控制，不会经常更新，所以只需要缓存在内存即可。即使出错也不影响正常逻辑，暂不引入redis
+    private val allTagCache: LoadingCache<String, List<PipelineStageTag>> = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofMinutes(1))
+        .maximumSize(1)
+        .build {
+            val pipelineStageTagList = mutableListOf<PipelineStageTag>()
+            pipelineStageTagDao.getAllStageTag(dslContext).forEachIndexed { index, record ->
+                pipelineStageTagList.add(pipelineStageTagDao.convert(record = record, defaultFlag = index == 0))
+            }
+            pipelineStageTagList
+        }
 
     /**
      * 获取所有阶段标签信息
      */
     fun getAllStageTag(): Result<List<PipelineStageTag>> {
-        val pipelineStageTagList = mutableListOf<PipelineStageTag>()
-        pipelineStageTagDao.getAllStageTag(dslContext).forEachIndexed { index, record ->
-            pipelineStageTagList.add(
-                pipelineStageTagDao.convert(record, index == 0)
-            )
-        }
-        return Result(pipelineStageTagList)
+        return Result(data = allTagCache.get(ALL) ?: emptyList())
     }
 
     /**
      * 获取默认标签
      */
     fun getDefaultStageTag(): Result<PipelineStageTag?> {
-        return Result(pipelineStageTagDao.getDefaultStageTag(dslContext))
+        return Result(data = defaultTagCache.get(DEFAULT))
     }
 
     /**
      * 根据id获取阶段标签信息
      */
     fun getStageTag(id: String): Result<PipelineStageTag?> {
-        val pipelineStageTagRecord = pipelineStageTagDao.getStageTag(dslContext, id)
-        logger.info("the pipelineStageTagRecord is :$pipelineStageTagRecord")
-        return Result(
-            if (pipelineStageTagRecord == null) {
-                null
-            } else {
-                pipelineStageTagDao.convert(pipelineStageTagRecord, false)
-            }
-        )
+        val all = allTagCache.getIfPresent(ALL)?.filter { it.id == id }
+        val data = if (all.isNullOrEmpty()) {
+            val pipelineStageTagRecord = pipelineStageTagDao.getStageTag(dslContext, id)
+            logger.info("the pipelineStageTagRecord is :$pipelineStageTagRecord")
+            pipelineStageTagRecord?.let { pipelineStageTagDao.convert(pipelineStageTagRecord, defaultFlag = false) }
+        } else {
+            all[0]
+        }
+        return Result(data = data)
     }
 
     /**
@@ -97,6 +119,8 @@ class StageTagService @Autowired constructor(
         }
         val id = UUIDUtil.generate()
         pipelineStageTagDao.add(dslContext, id, stageTag, weight)
+        defaultTagCache.invalidateAll()
+        allTagCache.invalidateAll()
         return Result(true)
     }
 
@@ -119,7 +143,8 @@ class StageTagService @Autowired constructor(
             }
         }
         pipelineStageTagDao.update(dslContext, id, stageTagName, weight)
-
+        defaultTagCache.invalidateAll()
+        allTagCache.invalidateAll()
         return Result(true)
     }
 
@@ -129,6 +154,8 @@ class StageTagService @Autowired constructor(
     fun deleteStageTag(id: String): Result<Boolean> {
         logger.info("the delete id is :{}", id)
         pipelineStageTagDao.delete(dslContext, id)
+        defaultTagCache.invalidateAll()
+        allTagCache.invalidateAll()
         return Result(true)
     }
 

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
@@ -28,39 +28,33 @@
 package com.tencent.devops.process.service.pipeline
 
 import com.tencent.devops.common.api.exception.ErrorCodeException
-import com.tencent.devops.common.api.util.EnvUtils
 import com.tencent.devops.common.pipeline.Model
 import com.tencent.devops.common.pipeline.container.TriggerContainer
 import com.tencent.devops.common.pipeline.enums.BuildFormPropertyType
 import com.tencent.devops.common.pipeline.enums.ChannelCode
 import com.tencent.devops.common.pipeline.enums.StartType
 import com.tencent.devops.common.pipeline.pojo.BuildParameters
-import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.redis.concurrent.SimpleRateLimiter
+import com.tencent.devops.common.service.trace.TraceTag
+import com.tencent.devops.process.bean.PipelineUrlBean
 import com.tencent.devops.process.constant.ProcessMessageCode
 import com.tencent.devops.process.engine.cfg.BuildIdGenerator
-import com.tencent.devops.process.engine.control.lock.PipelineBuildNumAliasLock
 import com.tencent.devops.process.engine.interceptor.InterceptData
 import com.tencent.devops.process.engine.interceptor.PipelineInterceptorChain
 import com.tencent.devops.process.engine.pojo.PipelineInfo
 import com.tencent.devops.process.engine.service.PipelineElementService
 import com.tencent.devops.process.engine.service.PipelineRepositoryService
 import com.tencent.devops.process.engine.service.PipelineRuntimeService
-import com.tencent.devops.process.engine.service.rule.PipelineRuleService
 import com.tencent.devops.process.pojo.app.StartBuildContext
-import com.tencent.devops.process.pojo.pipeline.enums.PipelineRuleBusCodeEnum
-import com.tencent.devops.process.pojo.setting.PipelineRunLockType
-import com.tencent.devops.process.pojo.setting.PipelineSetting
 import com.tencent.devops.process.service.ProjectCacheService
 import com.tencent.devops.process.util.BuildMsgUtils
-import com.tencent.devops.process.utils.BUILD_NO
+import com.tencent.devops.process.utils.PIPELINE_BUILD_ID
 import com.tencent.devops.process.utils.PIPELINE_BUILD_MSG
-import com.tencent.devops.process.utils.PIPELINE_BUILD_NUM_ALIAS
+import com.tencent.devops.process.utils.PIPELINE_BUILD_URL
 import com.tencent.devops.process.utils.PIPELINE_CREATE_USER
 import com.tencent.devops.process.utils.PIPELINE_ID
 import com.tencent.devops.process.utils.PIPELINE_NAME
 import com.tencent.devops.process.utils.PIPELINE_RETRY_BUILD_ID
-import com.tencent.devops.process.utils.PIPELINE_RETRY_COUNT
 import com.tencent.devops.process.utils.PIPELINE_SETTING_MAX_CON_QUEUE_SIZE_DEFAULT
 import com.tencent.devops.process.utils.PIPELINE_START_CHANNEL
 import com.tencent.devops.process.utils.PIPELINE_START_MANUAL_USER_ID
@@ -77,9 +71,8 @@ import com.tencent.devops.process.utils.PIPELINE_UPDATE_USER
 import com.tencent.devops.process.utils.PIPELINE_VERSION
 import com.tencent.devops.process.utils.PROJECT_NAME
 import com.tencent.devops.process.utils.PROJECT_NAME_CHINESE
-import com.tencent.devops.process.utils.PipelineVarUtil
 import com.tencent.devops.project.pojo.ProjectVO
-import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.stereotype.Service
 
 @Suppress("ALL")
@@ -90,13 +83,11 @@ class PipelineBuildService(
     private val pipelineRuntimeService: PipelineRuntimeService,
     private val pipelineElementService: PipelineElementService,
     private val projectCacheService: ProjectCacheService,
-    private val pipelineRuleService: PipelineRuleService,
-    private val redisOperation: RedisOperation,
+    private val pipelineUrlBean: PipelineUrlBean,
     private val simpleRateLimiter: SimpleRateLimiter,
     private val buildIdGenerator: BuildIdGenerator
 ) {
     companion object {
-        private val logger = LoggerFactory.getLogger(PipelineBuildService::class.java)
         private val NO_LIMIT_CHANNEL = listOf(ChannelCode.CODECC)
         private const val CONTEXT_PREFIX = "variables."
     }
@@ -117,12 +108,8 @@ class PipelineBuildService(
         triggerReviewers: List<String>? = null
     ): String {
 
-        val pipelineId = pipeline.pipelineId
         var acquire = false
-        val projectId = pipeline.projectId
-        val pipelineSetting = pipelineRepositoryService.getSetting(projectId, pipelineId)
-        val bucketSize = pipelineSetting!!.maxConRunningQueueSize
-        val projectVO = projectCacheService.getProject(projectId)
+        val projectVO = projectCacheService.getProject(pipeline.projectId)
         if (projectVO?.enabled == false) {
             throw ErrorCodeException(
                 errorCode = ProcessMessageCode.ERROR_START_BUILD_PROJECT_UNENABLE,
@@ -130,7 +117,10 @@ class PipelineBuildService(
                 params = arrayOf(projectVO.englishName)
             )
         }
-        val lockKey = "PipelineRateLimit:$pipelineId"
+
+        val setting = pipelineRepositoryService.getSetting(pipeline.projectId, pipeline.pipelineId)
+        val bucketSize = setting!!.maxConRunningQueueSize
+        val lockKey = "PipelineRateLimit:${pipeline.pipelineId}"
         try {
             if (frequencyLimit && channelCode !in NO_LIMIT_CHANNEL) {
                 acquire = simpleRateLimiter.acquire(
@@ -149,33 +139,30 @@ class PipelineBuildService(
             pipeline.version = signPipelineVersion ?: pipeline.version
 
             // 只有新构建才需要填充Post插件与质量红线插件
-            val isNewBuild = !pipelineParamMap.containsKey(PIPELINE_RETRY_COUNT)
-            if (isNewBuild) {
+            if (!pipelineParamMap.containsKey(PIPELINE_RETRY_BUILD_ID)) {
                 pipelineElementService.fillElementWhenNewBuild(
                     model = model,
-                    projectId = projectId,
-                    pipelineId = pipelineId,
+                    projectId = pipeline.projectId,
+                    pipelineId = pipeline.pipelineId,
                     startValues = startValues,
                     startParamsMap = pipelineParamMap,
                     handlePostFlag = handlePostFlag
                 )
             }
-            val setting = pipelineRepositoryService.getSetting(projectId, pipelineId)
 
-            val originStartParams = genOriginStartParams(
+            val buildId = pipelineParamMap[PIPELINE_RETRY_BUILD_ID]?.value?.toString() ?: buildIdGenerator.getNextId()
+
+            initPipelineParamMap(
+                buildId = buildId,
                 startType = startType,
                 pipelineParamMap = pipelineParamMap,
                 userId = userId,
                 startValues = startValues,
                 pipeline = pipeline,
                 projectVO = projectVO,
-                model = model,
                 channelCode = channelCode,
-                isMobile = isMobile,
-                projectId = projectId
+                isMobile = isMobile
             )
-
-            val buildId = pipelineParamMap[PIPELINE_RETRY_BUILD_ID]?.value?.toString() ?: buildIdGenerator.getNextId()
 
             val interceptResult = pipelineInterceptorChain.filter(
                 InterceptData(
@@ -195,39 +182,19 @@ class PipelineBuildService(
             }
 
             val context = StartBuildContext.init(
-                projectId = projectId,
-                pipelineId = pipelineId,
+                projectId = pipeline.projectId,
+                pipelineId = pipeline.pipelineId,
                 buildId = buildId,
                 resourceVersion = pipeline.version,
-                // 优化并发组逻辑，只在GROUP_LOCK时才保存进history表
-                concurrencyGroup = if (setting?.runLockType == PipelineRunLockType.GROUP_LOCK) {
-                    // #6987 修复stream的并发执行判断问题 在判断并发时再替换上下文
-                    setting.concurrencyGroup?.let {
-                        val varMap = pipelineParamMap.values.associate { param -> param.key to param.value.toString() }
-                        setting.concurrencyGroup = EnvUtils.parseEnv(it, PipelineVarUtil.fillContextVarMap(varMap))
-                        logger.info("[$pipelineId]|Concurrency Group is ${setting.concurrencyGroup}")
-                    }
-                    setting.concurrencyGroup
-                } else null,
-                params = pipelineParamMap.values.associate { it.key to it.value.toString() },
-                buildParameters = originStartParams,
+                pipelineSetting = setting,
                 currentBuildNo = buildNo,
                 triggerReviewers = triggerReviewers,
-                buildNumAlias = genBuildNumAlias(
-                    projectId = projectId,
-                    pipelineId = pipelineId,
-                    buildId = buildId,
-                    pipelineSetting = pipelineSetting,
-                    pipelineParamMap = pipelineParamMap
-                )
+                pipelineParamMap = pipelineParamMap,
+                // 解析出定义的流水线变量
+                realStartParamKeys = (model.stages[0].containers[0] as TriggerContainer).params.map { it.id }
             )
 
-            return pipelineRuntimeService.startBuild(
-                fullModel = model,
-                context = context,
-                // #5264 保留启动参数的原始值以及重试中需要用到的字段
-                pipelineParamMap = pipelineParamMap
-            )
+            return pipelineRuntimeService.startBuild(fullModel = model, context = context)
         } finally {
             if (acquire) {
                 simpleRateLimiter.release(lockKey = lockKey)
@@ -235,50 +202,17 @@ class PipelineBuildService(
         }
     }
 
-    private fun genBuildNumAlias(
-        projectId: String,
-        pipelineId: String,
+    private fun initPipelineParamMap(
         buildId: String,
-        pipelineSetting: PipelineSetting,
-        pipelineParamMap: MutableMap<String, BuildParameters>
-    ): String? {
-
-        var buildNumAlias: String? = null
-
-        (if (!pipelineSetting.buildNumRule.isNullOrBlank())
-            PipelineBuildNumAliasLock(redisOperation = redisOperation, pipelineId = pipelineId)
-        else null
-            )?.use { pipelineBuildNumAliasLock ->
-                pipelineBuildNumAliasLock.lock()
-                buildNumAlias = pipelineRuleService.parsePipelineRule(
-                    projectId = projectId,
-                    pipelineId = pipelineId,
-                    buildId = buildId,
-                    busCode = PipelineRuleBusCodeEnum.BUILD_NUM.name,
-                    ruleStr = pipelineSetting.buildNumRule!!
-                )
-
-                // 写自定义构建号信息
-                if (!buildNumAlias.isNullOrBlank()) {
-                    pipelineParamMap[PIPELINE_BUILD_NUM_ALIAS] =
-                        BuildParameters(key = PIPELINE_BUILD_NUM_ALIAS, value = buildNumAlias!!, readOnly = true)
-                }
-            }
-        return buildNumAlias
-    }
-
-    private fun genOriginStartParams(
         startType: StartType,
         pipelineParamMap: MutableMap<String, BuildParameters>,
         userId: String,
         startValues: Map<String, String>?,
         pipeline: PipelineInfo,
         projectVO: ProjectVO?,
-        model: Model,
         channelCode: ChannelCode,
-        isMobile: Boolean,
-        projectId: String
-    ): ArrayList<BuildParameters> {
+        isMobile: Boolean
+    ) {
         val userName = when (startType) {
             StartType.PIPELINE -> pipelineParamMap[PIPELINE_START_PIPELINE_USER_ID]?.value
             StartType.WEB_HOOK -> pipelineParamMap[PIPELINE_START_WEBHOOK_USER_ID]?.value
@@ -303,24 +237,24 @@ class PipelineBuildService(
         )
 
         // 解析出定义的流水线变量
-        val realStartParamKeys = (model.stages[0].containers[0] as TriggerContainer).params.map { it.id }
-        val originStartParams = ArrayList<BuildParameters>(realStartParamKeys.size + 4)
+//        val realStartParamKeys = (model.stages[0].containers[0] as TriggerContainer).params.map { it.id }
+//        val originStartParams = ArrayList<BuildParameters>(realStartParamKeys.size + 4)
 
         // 将用户定义的变量增加上下文前缀的版本，与原变量相互独立
-        val originStartContexts = ArrayList<BuildParameters>(realStartParamKeys.size)
-        realStartParamKeys.forEach { key ->
-            pipelineParamMap[key]?.let { param ->
-                originStartParams.add(param)
-                originStartContexts.add(
-                    if (key.startsWith(CONTEXT_PREFIX)) {
-                        param
-                    } else {
-                        param.copy(key = CONTEXT_PREFIX + key)
-                    }
-                )
-            }
-        }
-        pipelineParamMap.putAll(originStartContexts.associateBy { it.key })
+//        val originStartContexts = ArrayList<BuildParameters>(realStartParamKeys.size)
+//        realStartParamKeys.forEach { key ->
+//            pipelineParamMap[key]?.let { param ->
+//                originStartParams.add(param)
+//                originStartContexts.add(
+//                    if (key.startsWith(CONTEXT_PREFIX)) {
+//                        param
+//                    } else {
+//                        param.copy(key = CONTEXT_PREFIX + key)
+//                    }
+//                )
+//            }
+//        }
+//        pipelineParamMap.putAll(originStartContexts.associateBy { it.key })
 
         pipelineParamMap[PIPELINE_BUILD_MSG] = BuildParameters(
             key = PIPELINE_BUILD_MSG,
@@ -349,11 +283,32 @@ class PipelineBuildService(
         )
         pipelineParamMap[PIPELINE_VERSION] = BuildParameters(PIPELINE_VERSION, pipeline.version, readOnly = true)
         pipelineParamMap[PIPELINE_ID] = BuildParameters(PIPELINE_ID, pipeline.pipelineId, readOnly = true)
-        pipelineParamMap[PROJECT_NAME] = BuildParameters(PROJECT_NAME, projectId, readOnly = true)
+        pipelineParamMap[PROJECT_NAME] = BuildParameters(PROJECT_NAME, pipeline.projectId, readOnly = true)
+//
+//        pipelineParamMap[BUILD_NO]?.let { buildNoParam -> originStartParams.add(buildNoParam) }
+//        pipelineParamMap[PIPELINE_BUILD_MSG]?.let { buildMsgParam -> originStartParams.add(buildMsgParam) }
+//        pipelineParamMap[PIPELINE_RETRY_COUNT]?.let { retryCountParam -> originStartParams.add(retryCountParam) }
 
-        pipelineParamMap[BUILD_NO]?.let { buildNoParam -> originStartParams.add(buildNoParam) }
-        pipelineParamMap[PIPELINE_BUILD_MSG]?.let { buildMsgParam -> originStartParams.add(buildMsgParam) }
-        pipelineParamMap[PIPELINE_RETRY_COUNT]?.let { retryCountParam -> originStartParams.add(retryCountParam) }
-        return originStartParams
+        pipelineParamMap[PIPELINE_BUILD_ID] = BuildParameters(PIPELINE_BUILD_ID, buildId, readOnly = true)
+        pipelineParamMap[PIPELINE_BUILD_URL] = BuildParameters(
+            key = PIPELINE_BUILD_URL,
+            value = pipelineUrlBean.genBuildDetailUrl(
+                projectCode = pipeline.projectId,
+                pipelineId = pipeline.pipelineId,
+                buildId = buildId,
+                position = null,
+                stageId = null,
+                needShortUrl = false
+            ),
+            readOnly = true
+        )
+
+        // 链路
+        val bizId = MDC.get(TraceTag.BIZID)
+        if (!bizId.isNullOrBlank()) { // 保存链路信息
+            pipelineParamMap[TraceTag.TRACE_HEADER_DEVOPS_BIZID] =
+                BuildParameters(key = TraceTag.TRACE_HEADER_DEVOPS_BIZID, value = bizId)
+        }
+//        return originStartParams
     }
 }

--- a/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/context/StartBuildContextTest.kt
+++ b/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/context/StartBuildContextTest.kt
@@ -30,6 +30,7 @@ package com.tencent.devops.process.engine.context
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.ChannelCode
 import com.tencent.devops.common.pipeline.enums.StartType
+import com.tencent.devops.common.pipeline.pojo.BuildParameters
 import com.tencent.devops.process.TestBase
 import com.tencent.devops.process.engine.cfg.BuildIdGenerator
 import com.tencent.devops.process.engine.cfg.PipelineIdGenerator
@@ -106,19 +107,21 @@ class StartBuildContextTest : TestBase() {
         Assertions.assertEquals(false, needSkipContainerWhenFailRetry)
     }
 
-    private fun initDefaultStartBuildContext() = StartBuildContext.init(
-        projectId = projectId,
-        pipelineId = pipelineId,
-        buildId = buildId,
-        resourceVersion = version,
-        params = params,
-        buildParameters = mutableListOf(),
-        currentBuildNo = null,
-        concurrencyGroup = null,
-        buildNumAlias = null,
-        startBuildStatus = null,
-        triggerReviewers = null
-    )
+    private fun initDefaultStartBuildContext(): StartBuildContext {
+        val pipelineParamMap: MutableMap<String, BuildParameters> = params.toList().associate {
+            it.first to BuildParameters(key = it.first, value = it.second)
+        }.toMutableMap()
+        return StartBuildContext.init(
+            projectId = projectId,
+            pipelineId = pipelineId,
+            buildId = buildId,
+            resourceVersion = version,
+            realStartParamKeys = emptyList(),
+            pipelineParamMap = pipelineParamMap,
+            currentBuildNo = null,
+            triggerReviewers = null
+        )
+    }
 
     @Test
     fun needSkipTaskWhenRetry() {

--- a/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/context/StartBuildContextTest.kt
+++ b/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/context/StartBuildContextTest.kt
@@ -72,7 +72,7 @@ class StartBuildContextTest : TestBase() {
     fun needSkipWhenStageFailRetry() {
         params.remove(PIPELINE_RETRY_START_TASK_ID)
         params.remove(PIPELINE_RETRY_COUNT)
-        val context = StartBuildContext.init(projectId, pipelineId, buildId, version, params)
+        val context = initDefaultStartBuildContext()
         Assertions.assertEquals(params, context.variables)
         val stage = genStages(stageSize = 2, jobSize = 2, elementSize = 2, needFinally = false)[1]
         val needSkipWhenStageFailRetry = context.needSkipWhenStageFailRetry(stage)
@@ -83,22 +83,20 @@ class StartBuildContextTest : TestBase() {
     @Test
     fun needSkipContainerWhenFailRetry() {
         params[PIPELINE_RETRY_COUNT] = "abc"
-        var context = StartBuildContext.init(
-            projectId, pipelineId, buildId, version, params
-        )
+        var context = initDefaultStartBuildContext()
         Assertions.assertEquals(params, context.variables)
         Assertions.assertEquals(context.executeCount, 1)
 
         params[PIPELINE_RETRY_COUNT] = "2"
-        context = StartBuildContext.init(projectId, pipelineId, buildId, version, params)
+        context = initDefaultStartBuildContext()
         Assertions.assertEquals(context.executeCount, params[PIPELINE_RETRY_COUNT].toString().toInt() + 1)
 
         params[PIPELINE_START_CHANNEL] = ChannelCode.AM.name
-        context = StartBuildContext.init(projectId, pipelineId, buildId, version, params)
+        context = initDefaultStartBuildContext()
         Assertions.assertEquals(ChannelCode.AM, context.channelCode)
         params.remove(PIPELINE_START_CHANNEL)
 
-        context = StartBuildContext.init(projectId, pipelineId, buildId, version, params)
+        context = initDefaultStartBuildContext()
         Assertions.assertEquals(ChannelCode.BS, context.channelCode)
 
         val stage = genStages(stageSize = 2, jobSize = 2, elementSize = 2, needFinally = false)[1]
@@ -108,11 +106,23 @@ class StartBuildContextTest : TestBase() {
         Assertions.assertEquals(false, needSkipContainerWhenFailRetry)
     }
 
+    private fun initDefaultStartBuildContext() = StartBuildContext.init(
+        projectId = projectId,
+        pipelineId = pipelineId,
+        buildId = buildId,
+        resourceVersion = version,
+        params = params,
+        buildParameters = mutableListOf(),
+        currentBuildNo = null,
+        concurrencyGroup = null,
+        buildNumAlias = null,
+        startBuildStatus = null,
+        triggerReviewers = null
+    )
+
     @Test
     fun needSkipTaskWhenRetry() {
-        val context = StartBuildContext.init(
-            projectId, pipelineId, buildId, version, params
-        )
+        val context = initDefaultStartBuildContext()
         Assertions.assertEquals(params, context.variables)
         val stage = genStages(stageSize = 2, jobSize = 2, elementSize = 2, needFinally = false)[1]
         val container = stage.containers[0]
@@ -130,9 +140,7 @@ class StartBuildContextTest : TestBase() {
         params[PIPELINE_RETRY_START_TASK_ID] = "stage-2"
         params[PIPELINE_SKIP_FAILED_TASK] = true.toString()
 
-        val stage2Context = StartBuildContext.init(
-            projectId, pipelineId, buildId, version, params
-        )
+        val stage2Context = initDefaultStartBuildContext()
         Assertions.assertEquals(params, stage2Context.variables)
         val stages = genStages(stageSize = 2, jobSize = 2, elementSize = 2, needFinally = false)
         val stage1 = stages[1]
@@ -155,11 +163,10 @@ class StartBuildContextTest : TestBase() {
         // 指定跳过插件是 Stage-1 里的 插件
         params[PIPELINE_RETRY_START_TASK_ID] = stage1.containers[0].elements[0].id!!
         params[PIPELINE_SKIP_FAILED_TASK] = true.toString()
-        val skipElement = StartBuildContext.init(
-            projectId, pipelineId, buildId, version, params
-        )
+        val skipElement = initDefaultStartBuildContext()
         needSkipTaskWhenRetrySkip = skipElement.needSkipTaskWhenRetry(
-            stage = stages[2], container = container2, taskId = container2.elements[0].id)
+            stage = stages[2], container = container2, taskId = container2.elements[0].id
+        )
         println("needSkipTaskWhenRetrySkip=$needSkipTaskWhenRetrySkip")
         Assertions.assertEquals(true, needSkipTaskWhenRetrySkip)
     }
@@ -170,9 +177,7 @@ class StartBuildContextTest : TestBase() {
         params[PIPELINE_RETRY_START_TASK_ID] = "stage-2"
         params[PIPELINE_SKIP_FAILED_TASK] = true.toString()
 
-        val stage2Context = StartBuildContext.init(
-            projectId, pipelineId, buildId, version, params
-        )
+        val stage2Context = initDefaultStartBuildContext()
         Assertions.assertEquals(params, stage2Context.variables)
         val stages = genStages(stageSize = 2, jobSize = 2, elementSize = 2, needFinally = false)
         val stage1 = stages[1]
@@ -196,9 +201,7 @@ class StartBuildContextTest : TestBase() {
         // 指定跳过插件是 Stage-1 里 插件
         params[PIPELINE_RETRY_START_TASK_ID] = stage1.containers[0].elements[0].id!!
         params[PIPELINE_SKIP_FAILED_TASK] = true.toString()
-        val skipElement = StartBuildContext.init(
-            projectId, pipelineId, buildId, version, params
-        )
+        val skipElement = initDefaultStartBuildContext()
         // Stage-2 的插件不在重试时跳过的Stage内范围
         stage2.containers.forEach { c ->
             c.elements.forEach { e ->

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildEndControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildEndControl.kt
@@ -27,6 +27,7 @@
 
 package com.tencent.devops.process.engine.control
 
+import com.tencent.devops.common.api.constant.coerceAtMaxLength
 import com.tencent.devops.common.api.exception.ErrorCodeException
 import com.tencent.devops.common.api.pojo.ErrorCode.PLUGIN_DEFAULT_ERROR
 import com.tencent.devops.common.api.pojo.ErrorCode.USER_QUALITY_CHECK_FAIL
@@ -47,7 +48,6 @@ import com.tencent.devops.common.pipeline.pojo.BuildNoType
 import com.tencent.devops.common.pipeline.utils.BuildStatusSwitcher
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.service.prometheus.BkTimed
-import com.tencent.devops.common.service.utils.CommonUtils
 import com.tencent.devops.common.service.utils.LogUtils
 import com.tencent.devops.common.websocket.enum.RefreshType
 import com.tencent.devops.process.constant.ProcessMessageCode
@@ -300,9 +300,7 @@ class BuildEndControl @Autowired constructor(
                         atomCode = task.atomCode ?: task.taskParams["atomCode"] as String? ?: task.taskType,
                         errorType = task.errorType?.num ?: ErrorType.USER.num,
                         errorCode = task.errorCode ?: PLUGIN_DEFAULT_ERROR,
-                        errorMsg = CommonUtils.interceptStringInLength(
-                            string = task.errorMsg, length = PIPELINE_TASK_MESSAGE_STRING_LENGTH_MAX
-                        ) ?: ""
+                        errorMsg = task.errorMsg?.coerceAtMaxLength(PIPELINE_TASK_MESSAGE_STRING_LENGTH_MAX) ?: ""
                     )
                 )
                 // 做入库长度保护，假设超过上限则抛弃该错误信息
@@ -401,7 +399,11 @@ class BuildEndControl @Autowired constructor(
             varName = PIPELINE_TIME_END,
             varValue = endTime
         )
-        val duration = ((endTime - startTime) / 1000).toString()
+        val duration = if (startTime <= 0L) { // 未启动，直接取消的情况下，耗时不准确
+          "0"
+        } else {
+            ((endTime - startTime) / 1000).toString()
+        }
         buildVariableService.setVariable(
             projectId = this.projectId,
             pipelineId = this.pipelineId,

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildEndControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildEndControl.kt
@@ -400,7 +400,7 @@ class BuildEndControl @Autowired constructor(
             varValue = endTime
         )
         val duration = if (startTime <= 0L) { // 未启动，直接取消的情况下，耗时不准确
-          "0"
+            "0"
         } else {
             ((endTime - startTime) / 1000).toString()
         }

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildMonitorControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildMonitorControl.kt
@@ -230,12 +230,12 @@ class BuildMonitorControl @Autowired constructor(
             0
         }
 
-        val minute = (controlOption.jobControlOption.timeout ?: Timeout.DEFAULT_TIMEOUT_MIN).toLong()
-        val timeoutMills = TimeUnit.MINUTES.toMillis(minute)
+        val minute = controlOption.jobControlOption.timeout
+        val timeoutMills = Timeout.transMinuteTimeoutToMills(minute)
 
         buildLogPrinter.addDebugLine(
             buildId = buildId,
-            message = "[SystemLog]Check job timeout(${controlOption.jobControlOption.timeout} minutes), " +
+            message = "[SystemLog]Check job timeout($minute minutes), " +
                 "running: ${TimeUnit.MILLISECONDS.toMinutes(usedTimeMills)} minutes!",
             tag = VMUtils.genStartVMTaskId(containerId),
             jobId = containerHashId,

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildStartControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildStartControl.kt
@@ -678,6 +678,8 @@ class BuildStartControl @Autowired constructor(
                 varName = PIPELINE_TIME_START,
                 varValue = System.currentTimeMillis().toString()
             )
+            // 增加Model版本引用计数
+            pipelineRuntimeService.addVersionRef(buildInfo.projectId, buildInfo.pipelineId, buildInfo.version)
         }
 
         val stages = model.stages

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/container/impl/StartActionTaskContainerCmd.kt
@@ -40,6 +40,7 @@ import com.tencent.devops.common.pipeline.utils.BuildStatusSwitcher
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.common.service.utils.MessageCodeUtil
 import com.tencent.devops.process.constant.ProcessMessageCode
+import com.tencent.devops.process.engine.common.Timeout
 import com.tencent.devops.process.engine.common.VMUtils
 import com.tencent.devops.process.engine.control.ControlUtils
 import com.tencent.devops.process.engine.control.FastKillUtils
@@ -59,7 +60,6 @@ import com.tencent.devops.process.util.TaskUtils
 import com.tencent.devops.store.pojo.common.ATOM_POST_EXECUTE_TIP
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.concurrent.TimeUnit
 
 @Suppress("TooManyFunctions", "LongParameterList", "ComplexMethod")
 @Service
@@ -141,7 +141,7 @@ class StartActionTaskContainerCmd(
         val failedEvenCancelFlag = runCondition == RunCondition.PRE_TASK_FAILED_EVEN_CANCEL
         if (actionType == ActionType.END && failedEvenCancelFlag) {
             val container = commandContext.container
-            val timeout = container.controlOption.jobControlOption.timeout // 前面已经解析过
+            val timeoutSec = Timeout.transMinuteTimeoutToSec(container.controlOption.jobControlOption.timeout)
             redisOperation.set(
                 key = ContainerUtils.getContainerRunEvenCancelTaskKey(
                     pipelineId = waitToDoTask.pipelineId,
@@ -149,7 +149,7 @@ class StartActionTaskContainerCmd(
                     containerId = waitToDoTask.containerId
                 ),
                 value = waitToDoTask.taskId,
-                expiredInSecond = TimeUnit.MINUTES.toSeconds(timeout!!.toLong())
+                expiredInSecond = timeoutSec
             )
         }
     }

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/SubPipelineStartUpService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/SubPipelineStartUpService.kt
@@ -43,7 +43,6 @@ import com.tencent.devops.common.pipeline.pojo.element.market.MarketBuildLessAto
 import com.tencent.devops.common.service.utils.MessageCodeUtil
 import com.tencent.devops.process.constant.ProcessMessageCode
 import com.tencent.devops.process.engine.compatibility.BuildParametersCompatibilityTransformer
-import com.tencent.devops.process.engine.dao.PipelineBuildTaskDao
 import com.tencent.devops.process.engine.service.PipelineRepositoryService
 import com.tencent.devops.process.engine.service.PipelineRuntimeService
 import com.tencent.devops.process.engine.service.PipelineTaskService
@@ -63,7 +62,6 @@ import com.tencent.devops.process.utils.PIPELINE_START_PIPELINE_USER_ID
 import com.tencent.devops.process.utils.PIPELINE_START_USER_ID
 import com.tencent.devops.process.utils.PIPELINE_START_USER_NAME
 import com.tencent.devops.process.utils.PipelineVarUtil
-import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import javax.ws.rs.core.Response
@@ -88,12 +86,6 @@ abstract class SubPipelineStartUpService @Autowired constructor() {
 
     @Autowired
     lateinit var pipelineRuntimeService: PipelineRuntimeService
-
-    @Autowired
-    lateinit var pipelineBuildTaskDao: PipelineBuildTaskDao
-
-    @Autowired
-    lateinit var dslContext: DSLContext
 
     @Autowired
     lateinit var subPipelineStatusService: SubPipelineStatusService
@@ -183,8 +175,7 @@ abstract class SubPipelineStartUpService @Autowired constructor() {
             parameters = startParams,
             triggerUser = triggerUser
         )
-        pipelineBuildTaskDao.updateSubBuildId(
-            dslContext = dslContext,
+        pipelineTaskService.updateSubBuildId(
             projectId = projectId,
             buildId = buildId,
             taskId = taskId,
@@ -450,7 +441,7 @@ abstract class SubPipelineStartUpService @Autowired constructor() {
     }
 
     fun getSubVar(projectId: String, buildId: String, taskId: String): Result<Map<String, String>> {
-        val task = pipelineBuildTaskDao.get(dslContext, projectId = projectId, buildId = buildId, taskId = taskId)
+        val task = pipelineTaskService.getByTaskId(projectId = projectId, buildId = buildId, taskId = taskId)
             ?: return Result(emptyMap())
 
         logger.info("getSubVar sub build :${task.subBuildId}|${task.subProjectId}")

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/builds/PipelineBuildFacadeService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/builds/PipelineBuildFacadeService.kt
@@ -926,10 +926,7 @@ class PipelineBuildFacadeService(
         }
         val executeCount = buildInfo.executeCount ?: 1
         if (approve) {
-            pipelineRuntimeService.approveTriggerReview(
-                userId = userId, buildId = buildId, pipelineId = pipelineId, projectId = projectId,
-                resourceVersion = buildInfo.version, executeCount = executeCount
-            )
+            pipelineRuntimeService.approveTriggerReview(userId = userId, buildInfo = buildInfo)
         } else {
             pipelineRuntimeService.disapproveTriggerReview(
                 userId = userId, buildId = buildId, pipelineId = pipelineId,

--- a/src/backend/ci/core/project/biz-project/src/main/kotlin/com/tencent/devops/project/dao/ProjectDao.kt
+++ b/src/backend/ci/core/project/biz-project/src/main/kotlin/com/tencent/devops/project/dao/ProjectDao.kt
@@ -28,7 +28,7 @@
 package com.tencent.devops.project.dao
 
 import com.tencent.devops.common.api.util.JsonUtil
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.project.tables.TProject
 import com.tencent.devops.model.project.tables.records.TProjectRecord
 import com.tencent.devops.project.pojo.OpProjectUpdateInfoRequest

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/dao/atom/AtomBaseDao.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/dao/atom/AtomBaseDao.kt
@@ -27,7 +27,7 @@
 
 package com.tencent.devops.store.dao.atom
 
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.store.tables.TAtom
 import com.tencent.devops.model.store.tables.records.TAtomRecord
 import com.tencent.devops.store.pojo.atom.enums.AtomStatusEnum

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/dao/atom/AtomDao.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/dao/atom/AtomDao.kt
@@ -38,7 +38,7 @@ import com.tencent.devops.common.api.constant.KEY_WEIGHT
 import com.tencent.devops.common.api.constant.NAME
 import com.tencent.devops.common.api.constant.VERSION
 import com.tencent.devops.common.api.util.JsonUtil
-import com.tencent.devops.common.service.utils.JooqUtils
+import com.tencent.devops.common.db.utils.JooqUtils
 import com.tencent.devops.model.store.tables.TAtom
 import com.tencent.devops.model.store.tables.TAtomFeature
 import com.tencent.devops.model.store.tables.TClassify

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/dao/common/StoreStatisticDailyDao.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/dao/common/StoreStatisticDailyDao.kt
@@ -29,7 +29,7 @@ package com.tencent.devops.store.dao.common
 
 import com.tencent.devops.common.api.util.JsonUtil
 import com.tencent.devops.common.api.util.UUIDUtil
-import com.tencent.devops.common.service.utils.JooqUtils.sum
+import com.tencent.devops.common.db.utils.JooqUtils.sum
 import com.tencent.devops.model.store.tables.TStoreStatisticsDaily
 import com.tencent.devops.model.store.tables.records.TStoreStatisticsDailyRecord
 import com.tencent.devops.store.pojo.common.BK_SUM_DAILY_FAIL_NUM


### PR DESCRIPTION

1、优化Tag等无关紧要的数据增加缓存
2、优化构建启动时批量写变量的性能（去锁）
3、优化构建数据的批量插入（batch SQL）
4、增加性能监控
5、  修正未启动，直接取消的情况下，通知模板显示的耗时不准确
6、对于三大Build分区表【created_time】分区字段在update更新中没有作为查询条件，会在新建分区时并发偶现死锁，进行一次重试解决