### PR TITLE
bugfix: 并发组优化 #8809

### DIFF
--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/pojo/app/StartBuildContext.kt
@@ -273,7 +273,7 @@ data class StartBuildContext(
                 buildParameters = genOriginStartParamsList(realStartParamKeys, pipelineParamMap),
                 // 优化并发组逻辑，只在GROUP_LOCK时才保存进history表
                 concurrencyGroup = pipelineSetting?.takeIf { it.runLockType == PipelineRunLockType.GROUP_LOCK }
-                    ?.concurrencyGroup.let {
+                    ?.concurrencyGroup?.let {
                         val tConcurrencyGroup = EnvUtils.parseEnv(it, PipelineVarUtil.fillContextVarMap(params))
                         logger.info("[$pipelineId]|[$buildId]|ConcurrencyGroup=$tConcurrencyGroup")
                         tConcurrencyGroup

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -895,6 +895,7 @@ class PipelineRuntimeService @Autowired constructor(
             buildHistoryRecord.endTime = null
             buildHistoryRecord.queueTime = context.now // for EPC
             buildHistoryRecord.status = context.startBuildStatus.ordinal
+            buildHistoryRecord.concurrencyGroup = context.concurrencyGroup
             // 重试时启动参数只需要刷新执行次数
             buildHistoryRecord.buildParameters = buildHistoryRecord.buildParameters?.let { self ->
                 val retryCount = context.executeCount - 1


### PR DESCRIPTION
#8809
修复两个问题：
①选择并发运行时，却也注册了一个值为空的并发组（正常时应当为null）
②流水线整体重试时，注册的并发组没有更新。（保存的依旧是第一次触发的值）