### PR TITLE
feat: 支持获取构建环境的构建机列表 #8947

### DIFF
--- a/src/backend/ci/core/environment/api-environment/src/main/kotlin/com/tencent/devops/environment/api/ServiceNodeResource.kt
+++ b/src/backend/ci/core/environment/api-environment/src/main/kotlin/com/tencent/devops/environment/api/ServiceNodeResource.kt
@@ -173,4 +173,22 @@ interface ServiceNodeResource {
         @QueryParam("agentId")
         agentId: String
     ): Result<Boolean>
+
+    @ApiOperation("指定构建环境获取所有节点信息")
+    @GET
+    @Path("/projects/{projectId}/third_party_env2nodes")
+    fun thirdPartyEnv2Nodes(
+        @ApiParam(value = "用户ID", required = true, defaultValue = AUTH_HEADER_USER_ID_DEFAULT_VALUE)
+        @HeaderParam(AUTH_HEADER_USER_ID)
+        userId: String,
+        @ApiParam("项目ID(项目英文名)", required = true)
+        @PathParam("projectId")
+        projectId: String,
+        @ApiParam("环境 hashId (envHashId和envName选填一项)", required = false)
+        @QueryParam("envHashId")
+        envHashId: String?,
+        @ApiParam("环境名称", required = false)
+        @QueryParam("envName (envHashId和envName选填一项)")
+        envName: String?
+    ): Result<List<NodeWithPermission>>
 }

--- a/src/backend/ci/core/environment/api-environment/src/main/kotlin/com/tencent/devops/environment/api/ServiceNodeResource.kt
+++ b/src/backend/ci/core/environment/api-environment/src/main/kotlin/com/tencent/devops/environment/api/ServiceNodeResource.kt
@@ -187,8 +187,8 @@ interface ServiceNodeResource {
         @ApiParam("环境 hashId (envHashId和envName选填一项)", required = false)
         @QueryParam("envHashId")
         envHashId: String?,
-        @ApiParam("环境名称", required = false)
-        @QueryParam("envName (envHashId和envName选填一项)")
+        @ApiParam("环境名称 (envHashId和envName选填一项)", required = false)
+        @QueryParam("envName")
         envName: String?
     ): Result<List<NodeWithPermission>>
 }

--- a/src/backend/ci/core/environment/biz-environment/src/main/kotlin/com/tencent/devops/environment/dao/NodeDao.kt
+++ b/src/backend/ci/core/environment/biz-environment/src/main/kotlin/com/tencent/devops/environment/dao/NodeDao.kt
@@ -61,11 +61,16 @@ class NodeDao {
         }
     }
 
-    fun listThirdpartyNodes(dslContext: DSLContext, projectId: String): List<TNodeRecord> {
+    fun listThirdpartyNodes(
+        dslContext: DSLContext,
+        projectId: String,
+        nodeIds: Collection<Long>? = null
+    ): List<TNodeRecord> {
         with(TNode.T_NODE) {
             return dslContext.selectFrom(this)
                 .where(PROJECT_ID.eq(projectId))
                 .and(NODE_TYPE.eq(NodeType.THIRDPARTY.name))
+                .let { if (nodeIds != null) it.and(NODE_ID.`in`(nodeIds)) else it }
                 .orderBy(NODE_ID.desc())
                 .fetch()
         }

--- a/src/backend/ci/core/environment/biz-environment/src/main/kotlin/com/tencent/devops/environment/resources/ServiceNodeResourceImpl.kt
+++ b/src/backend/ci/core/environment/biz-environment/src/main/kotlin/com/tencent/devops/environment/resources/ServiceNodeResourceImpl.kt
@@ -119,4 +119,25 @@ class ServiceNodeResourceImpl @Autowired constructor(
         nodeService.deleteNodeByAgentId(userId, projectId, agentId)
         return Result(true)
     }
+
+    override fun thirdPartyEnv2Nodes(
+        userId: String,
+        projectId: String,
+        envHashId: String?,
+        envName: String?
+    ): Result<List<NodeWithPermission>> {
+        if (envHashId.isNullOrBlank() && envName.isNullOrBlank()) {
+            throw ErrorCodeException(
+                errorCode = CommonMessageCode.ERROR_NEED_PARAM_,
+                params = arrayOf("envHashId")
+            )
+        }
+        val envId = envHashId ?: envName?.let {
+            envService.getByName(projectId, it)?.envHashId
+        } ?: throw ErrorCodeException(
+            errorCode = CommonMessageCode.ERROR_NEED_PARAM_,
+            params = arrayOf("envName")
+        )
+        return Result(envService.thirdPartyEnv2Nodes(userId, projectId, envId))
+    }
 }

--- a/src/backend/ci/core/environment/biz-environment/src/main/kotlin/com/tencent/devops/environment/service/NodeService.kt
+++ b/src/backend/ci/core/environment/biz-environment/src/main/kotlin/com/tencent/devops/environment/service/NodeService.kt
@@ -53,16 +53,17 @@ import com.tencent.devops.environment.service.node.NodeActionFactory
 import com.tencent.devops.environment.service.slave.SlaveGatewayService
 import com.tencent.devops.environment.utils.AgentStatusUtils.getAgentStatus
 import com.tencent.devops.environment.utils.NodeStringIdUtils
-import java.time.format.DateTimeFormatter
-import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
+import com.tencent.devops.model.environment.tables.records.TNodeRecord
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 @Service
 @Suppress("ALL")
@@ -131,6 +132,14 @@ class NodeService @Autowired constructor(
             return emptyList()
         }
 
+        return formatNodeWithPermissions(userId, projectId, nodeRecordList)
+    }
+
+    fun formatNodeWithPermissions(
+        userId: String,
+        projectId: String,
+        nodeRecordList: List<TNodeRecord>
+    ): List<NodeWithPermission> {
         val permissionMap = environmentPermissionService.listNodeByPermissions(
             userId = userId, projectId = projectId,
             permissions = setOf(AuthPermission.USE, AuthPermission.EDIT, AuthPermission.DELETE)

--- a/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/api/apigw/v4/environment/ApigwEnvironmentResourceV4.kt
+++ b/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/api/apigw/v4/environment/ApigwEnvironmentResourceV4.kt
@@ -359,4 +359,22 @@ interface ApigwEnvironmentResourceV4 {
         @ApiParam(value = "共享的项目列表", required = true)
         sharedProjects: SharedProjectInfoWrap
     ): Result<Boolean>
+
+    @ApiOperation("指定构建环境获取所有节点信息", tags = ["v4_user_third_party_env2nodes", "v4_app_third_party_env2nodes"])
+    @GET
+    @Path("/third_party_env2nodes")
+    fun thirdPartyEnv2Nodes(
+        @ApiParam(value = "用户ID", required = true, defaultValue = AUTH_HEADER_USER_ID_DEFAULT_VALUE)
+        @HeaderParam(AUTH_HEADER_USER_ID)
+        userId: String,
+        @ApiParam("项目ID(项目英文名)", required = true)
+        @PathParam("projectId")
+        projectId: String,
+        @ApiParam("环境 hashId (envHashId和envName选填一项)", required = false)
+        @QueryParam("envHashId")
+        envHashId: String?,
+        @ApiParam("环境名称", required = false)
+        @QueryParam("envName (envHashId和envName选填一项)")
+        envName: String?
+    ): Result<List<NodeWithPermission>>
 }

--- a/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/api/apigw/v4/environment/ApigwEnvironmentResourceV4.kt
+++ b/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/api/apigw/v4/environment/ApigwEnvironmentResourceV4.kt
@@ -373,8 +373,8 @@ interface ApigwEnvironmentResourceV4 {
         @ApiParam("环境 hashId (envHashId和envName选填一项)", required = false)
         @QueryParam("envHashId")
         envHashId: String?,
-        @ApiParam("环境名称", required = false)
-        @QueryParam("envName (envHashId和envName选填一项)")
+        @ApiParam("环境名称 (envHashId和envName选填一项)", required = false)
+        @QueryParam("envName")
         envName: String?
     ): Result<List<NodeWithPermission>>
 }

--- a/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/utils/markdown/Table.kt
+++ b/src/backend/ci/core/openapi/api-openapi/src/main/kotlin/com/tencent/devops/openapi/utils/markdown/Table.kt
@@ -1,6 +1,6 @@
 package com.tencent.devops.openapi.utils.markdown
 
-import com.tencent.devops.common.web.utils.I18nUtil
+import com.tencent.devops.common.api.util.MessageUtil
 import com.tencent.devops.openapi.constant.OpenAPIMessageCode.BK_NO_SUCH_PARAMETER
 import com.tencent.devops.openapi.utils.markdown.MarkdownCharacter.FILL
 import com.tencent.devops.openapi.utils.markdown.MarkdownCharacter.MIN_FILL
@@ -20,7 +20,7 @@ class Table(
         val body = StringBuffer()
         if (rows.isEmpty()) {
             body.append(
-                Text(6, I18nUtil.getCodeLanMessage(BK_NO_SUCH_PARAMETER), "")
+                Text(6, MessageUtil.getMessageByLocale(BK_NO_SUCH_PARAMETER, "zh_CN"), "")
             )
             return body.toString()
         }

--- a/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/resources/apigw/v4/environment/ApigwEnvironmentResourceV4Impl.kt
+++ b/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/resources/apigw/v4/environment/ApigwEnvironmentResourceV4Impl.kt
@@ -208,6 +208,16 @@ class ApigwEnvironmentResourceV4Impl @Autowired constructor(
         return client.get(ServiceEnvironmentResource::class).setShareEnv(userId, projectId, envHashId, sharedProjects)
     }
 
+    override fun thirdPartyEnv2Nodes(
+        userId: String,
+        projectId: String,
+        envHashId: String?,
+        envName: String?
+    ): Result<List<NodeWithPermission>> {
+        logger.info("OPENAPI_ENVIRONMENT_V4|$userId|third party env2nodes|$projectId|$envHashId|$envName")
+        return client.get(ServiceNodeResource::class).thirdPartyEnv2Nodes(userId, projectId, envHashId, envName)
+    }
+
     companion object {
         private val logger = LoggerFactory.getLogger(ApigwEnvironmentResourceV4Impl::class.java)
     }

--- a/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/service/doc/DocumentService.kt
+++ b/src/backend/ci/core/openapi/biz-openapi/src/main/kotlin/com/tencent/devops/openapi/service/doc/DocumentService.kt
@@ -30,7 +30,7 @@ import com.tencent.devops.common.api.auth.AUTH_HEADER_DEVOPS_APP_CODE
 import com.tencent.devops.common.api.auth.AUTH_HEADER_USER_ID
 import com.tencent.devops.common.api.util.FileUtil
 import com.tencent.devops.common.api.util.JsonUtil
-import com.tencent.devops.common.web.utils.I18nUtil
+import com.tencent.devops.common.api.util.MessageUtil
 import com.tencent.devops.openapi.constant.OpenAPIMessageCode.BK_ALL_MODEL_DATA
 import com.tencent.devops.openapi.constant.OpenAPIMessageCode.BK_APPLICATION_STATE_REQUIRED
 import com.tencent.devops.openapi.constant.OpenAPIMessageCode.BK_BODY_PARAMETER
@@ -827,8 +827,9 @@ class DocumentService {
     }
 
     private fun getI18n(code: String, params: Array<String>? = null): String {
-        return I18nUtil.getCodeLanMessage(
+        return MessageUtil.getMessageByLocale(
             messageCode = code,
+            language = "zh_CN",
             params = params
         )
     }


### PR DESCRIPTION
#8947
①新增了一个openapi接口，解决目前openapi不能拿到第三方构建环境下构建机的数据（只能拿部署环境的）
②修复了下之前不小心漏掉的"重试时只有最新的构建才能刷新LATEST_STATUS"