### PR TITLE
bug: 【蓝盾新版权限】取消权限申请后，申请其他操作权限跳转页面筛选选择的用户组会一直复用上一次的 #9077

### DIFF
--- a/src/frontend/devops-permission/src/views/applyPermission/apply-permission.vue
+++ b/src/frontend/devops-permission/src/views/applyPermission/apply-permission.vue
@@ -136,9 +136,10 @@ const handleSubmit = () => {
 };
 
 const handleCancel = () => {
+  sessionStorage.removeItem('group-apply-query');
   router.push({
     name: 'my-permission'
-  })
+  });
 };
 
 const handleChangeGroup = (values) => {

--- a/src/frontend/devops-pipeline/src/views/subpages/edit.vue
+++ b/src/frontend/devops-pipeline/src/views/subpages/edit.vue
@@ -208,11 +208,12 @@
                 'requestQualityAtom',
                 'requestInterceptAtom'
             ]),
-            init () {
+            async init () {
                 if (!this.isDraftEdit) {
                     this.isLoading = true
-                    this.requestPipeline(this.$route.params)
-                    this.requestPipelineSetting(this.$route.params)
+                    await this.requestPipeline(this.$route.params)
+                    await this.requestPipelineSetting(this.$route.params)
+                    this.isLoading = false
                 }
             },
             switchTab (tab) {


### PR DESCRIPTION
 #9077