### PR TITLE
bug: linux操作系统cpu架构为aarch64应该使用arm64的node包执行node插件 #9070

### DIFF
--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/MessageUtil.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/MessageUtil.kt
@@ -73,7 +73,7 @@ object MessageUtil {
             // 通过resourceBundle获取对应语言的描述信息
             message = String(resourceBundle.getString(messageCode).toByteArray(Charsets.ISO_8859_1), Charsets.UTF_8)
         } catch (ignored: Throwable) {
-            logger.warn("Fail to get i18nMessage of messageCode[$messageCode]", ignored)
+            logger.warn("Fail to get i18nMessage of messageCode[$messageCode]")
         }
         if (null != params && null != message) {
             val mf = MessageFormat(message)
@@ -81,7 +81,7 @@ object MessageUtil {
             message = mf.format(params)
         }
         val res = message ?: defaultMessage ?: ""
-        return if (checkUrlDecoder) URLDecoder.decode(res, "UTF-8") else res
+        return if (checkUrlDecoder) URLDecoder.decode(res, Charsets.UTF_8.name()) else res
     }
 
     /**

--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/utils/I18nUtil.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/utils/I18nUtil.kt
@@ -61,6 +61,10 @@ object I18nUtil {
             // 本地缓存中获取不到语言信息再从redis中获取
             val redisOperation: RedisOperation = SpringContextUtil.getBean(RedisOperation::class.java)
             language = redisOperation.get(LocaleUtil.getUserLocaleLanguageKey(userId))
+            if (!language.isNullOrBlank()) {
+                // 如果redis中用户语言不为空，则把用户的语言缓存到本地
+                BkI18nLanguageCacheUtil.put(userId, language)
+            }
         }
         return language
     }

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/NodeJsAtomBusHandleHandleServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/service/atom/impl/NodeJsAtomBusHandleHandleServiceImpl.kt
@@ -60,7 +60,7 @@ class NodeJsAtomBusHandleHandleServiceImpl : AtomBusHandleService {
         }
         return when (osType) {
             OSType.LINUX, OSType.MAC_OS -> {
-                if (osArch.contains("arm")) {
+                if (osArch.contains("arm") || osArch.contains("aarch")) {
                     "arm64"
                 } else {
                     "x64"


### PR DESCRIPTION
bug: linux操作系统cpu架构为aarch64应该使用arm64的node包执行node插件 #9070
#9070