### PR TITLE
feat: 包含动态跳过插件任务的Job的调度逻辑优化 #9101

### DIFF
--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/utils/BkI18nLanguageCacheUtil.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/utils/BkI18nLanguageCacheUtil.kt
@@ -41,7 +41,7 @@ object BkI18nLanguageCacheUtil {
 
     private val i18nLanguageCache = Caffeine.newBuilder()
         .maximumSize(20000)
-        .expireAfterWrite(6, TimeUnit.SECONDS)
+        .expireAfterWrite(1, TimeUnit.MINUTES)
         .build<String, String>()
 
     /**

--- a/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/dao/ThirdPartyAgentBuildDao.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/dao/ThirdPartyAgentBuildDao.kt
@@ -176,21 +176,23 @@ class ThirdPartyAgentBuildDao {
         }
     }
 
-    fun getPreBuildAgent(
+    fun getPreBuildAgentIds(
         dslContext: DSLContext,
         projectId: String,
         pipelineId: String,
-        vmSeqId: String
-    ): Result<TDispatchThirdpartyAgentBuildRecord> {
+        vmSeqId: String,
+        size: Int
+    ): List<String> {
         with(TDispatchThirdpartyAgentBuild.T_DISPATCH_THIRDPARTY_AGENT_BUILD) {
-            return dslContext.selectFrom(this.forceIndex("IDX_PROJECT_PIPELINE_SEQ_STATUS_TIME"))
+            return dslContext.selectDistinct(AGENT_ID) // 修复获取最近构建构建机超过10次不构建会被驱逐出最近构建机列表的BUG
+                .from(this.forceIndex("IDX_PROJECT_PIPELINE_SEQ_STATUS_TIME"))
                 .where(PROJECT_ID.eq(projectId))
                 .and(PIPELINE_ID.eq(pipelineId))
                 .and(VM_SEQ_ID.eq(vmSeqId))
                 .and(STATUS.eq(PipelineTaskStatus.DONE.status))
                 .orderBy(CREATED_TIME.desc())
-                .limit(10)
-                .fetch()
+                .limit(size)
+                .fetch(AGENT_ID, String::class.java)
         }
     }
 

--- a/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/service/ThirdPartyAgentService.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/service/ThirdPartyAgentService.kt
@@ -43,7 +43,6 @@ import com.tencent.devops.common.client.Client
 import com.tencent.devops.common.pipeline.type.agent.ThirdPartyAgentDockerInfoDispatch
 import com.tencent.devops.common.redis.RedisOperation
 import com.tencent.devops.dispatch.dao.ThirdPartyAgentBuildDao
-import com.tencent.devops.dispatch.pojo.ThirdPartyAgentPreBuildAgents
 import com.tencent.devops.dispatch.pojo.enums.PipelineTaskStatus
 import com.tencent.devops.dispatch.pojo.thirdPartyAgent.AgentBuildInfo
 import com.tencent.devops.dispatch.pojo.thirdPartyAgent.BuildJobType
@@ -116,20 +115,14 @@ class ThirdPartyAgentService @Autowired constructor(
         }
     }
 
-    fun getPreBuildAgents(projectId: String, pipelineId: String, vmSeqId: String): List<ThirdPartyAgentPreBuildAgents> {
-        val records = thirdPartyAgentBuildDao.getPreBuildAgent(
-            dslContext, projectId, pipelineId, vmSeqId
+    fun getPreBuildAgentIds(projectId: String, pipelineId: String, vmSeqId: String, size: Int): List<String> {
+        return thirdPartyAgentBuildDao.getPreBuildAgentIds(
+            dslContext = dslContext,
+            projectId = projectId,
+            pipelineId = pipelineId,
+            vmSeqId = vmSeqId,
+            size = size
         )
-        return records.map {
-            ThirdPartyAgentPreBuildAgents(
-                id = it.id,
-                projectId = it.projectId,
-                agentId = it.agentId,
-                buildId = it.buildId,
-                status = it.status,
-                createdTime = it.createdTime.timestamp()
-            )
-        }
     }
 
     fun getRunningBuilds(agentId: String): Int {

--- a/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/service/dispatcher/agent/ThirdPartyAgentDispatcher.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/service/dispatcher/agent/ThirdPartyAgentDispatcher.kt
@@ -518,19 +518,19 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
         val pbAgents = sortAgent(event, dispatchType, preBuildAgents, runningBuildsMapper, dockerRunningBuildsMapper)
         /**
          * 1. 最高优先级的agent:
-         *     a. 最近构建机中使用过这个构建机
+         *     a. 最近构建机中使用过这个构建机,并且
          *     b. 当前没有任何构建机任务
          * 2. 次高优先级的agent:
-         *     a. 最近构建机中使用过这个构建机
-         *     b. 当前有构建任务，但是构建任务数量没有达到当前构建机的最大并发数
+         *     a. 最近构建机中使用过这个构建机,并且
+         *     b. 当前有构建任务,选当前正在运行任务最少的构建机(没有达到当前构建机的最大并发数)
          * 3. 第三优先级的agent:
          *     a. 当前没有任何构建机任务
          * 4. 第四优先级的agent:
-         *     a. 当前有构建任务，但是构建任务数量没有达到当前构建机的最大并发数
+         *     a. 当前有构建任务,选当前正在运行任务最少的构建机(没有达到当前构建机的最大并发数)
          */
 
         /**
-         * 根据哪些agent没有任何任务并且是在最近构建中使用到的Agent
+         * 最高优先级的agent: 根据哪些agent没有任何任务并且是在最近构建中使用到的Agent
          */
         logDebug(
             buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
@@ -552,7 +552,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                     )
         )
         /**
-         * 根据哪些agent有任务并且是在最近构建中使用到的Agent，同时当前构建任务还没到达该Agent最大并行数
+         * 次高优先级的agent: 最近构建机中使用过这个构建机,并且当前有构建任务,选当前正在运行任务最少的构建机(没有达到当前构建机的最大并发数)
          */
         if (startAvailableAgents(event, dispatchType, pbAgents, hasTryAgents)) {
             logger.info("${event.buildId}|START_AGENT|j(${event.vmSeqId})|dispatchType=$dispatchType|Get Lv.2")
@@ -568,7 +568,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
         )
         val allAgents = sortAgent(event, dispatchType, activeAgents, runningBuildsMapper, dockerRunningBuildsMapper)
         /**
-         * 根据哪些agent没有任何任务
+         * 第三优先级的agent: 当前没有任何构建机任务
          */
         if (startEmptyAgents(event, dispatchType, allAgents, hasTryAgents)) {
             logger.info("${event.buildId}|START_AGENT|j(${event.vmSeqId})|dispatchType=$dispatchType|pickup Lv.3")
@@ -583,7 +583,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                     )
         )
         /**
-         * 根据哪些agent有任务，同时当前构建任务还没到达该Agent最大并行数
+         * 第四优先级的agent: 当前有构建任务,选当前正在运行任务最少的构建机(没有达到当前构建机的最大并发数)
          */
         if (startAvailableAgents(event, dispatchType, allAgents, hasTryAgents)
         ) {

--- a/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/service/dispatcher/agent/ThirdPartyAgentDispatcher.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/service/dispatcher/agent/ThirdPartyAgentDispatcher.kt
@@ -71,7 +71,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Component
-@Suppress("ALL")
+@Suppress("UNUSED", "ComplexMethod", "LongMethod", "NestedBlockDepth", "MagicNumber")
 class ThirdPartyAgentDispatcher @Autowired constructor(
     private val client: Client,
     private val redisOperation: RedisOperation,
@@ -289,7 +289,8 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                     event,
                     ErrorCodeEnum.BUILD_MACHINE_BUSY.getErrorMessage(
                         language = I18nUtil.getDefaultLocaleLanguage()
-                    ) + "(Agent is busy) - ${agent.hostname}/${agent.ip}")
+                    ) + "(Agent is busy) - ${agent.hostname}/${agent.ip}"
+                )
                 return false
             }
         } finally {
@@ -347,7 +348,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
         )
     }
 
-    @Suppress("ComplexMethod", "LongMethod")
+    @Suppress("ComplexMethod", "LongMethod", "NestedBlockDepth", "MagicNumber")
     private fun buildByEnvId(event: PipelineAgentStartupEvent, dispatchType: ThirdPartyAgentEnvDispatchType) {
         val agentsResult = try {
             when (dispatchType.agentType) {
@@ -449,8 +450,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
             return
         }
 
-        val redisLock = ThirdPartyAgentEnvLock(redisOperation, event.projectId, dispatchType.envName)
-        try {
+        ThirdPartyAgentEnvLock(redisOperation, event.projectId, dispatchType.envName).use { redisLock ->
             val lock = redisLock.tryLock(timeout = 5000) // # 超时尝试锁定，防止环境过热锁定时间过长，影响其他环境构建
             if (lock) {
                 /**
@@ -462,161 +462,9 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                 val activeAgents = agentsResult.data!!.filter {
                     it.status == AgentStatus.IMPORT_OK &&
                             (event.os == it.os || event.os == VMBaseOS.ALL.name)
-                }.toHashSet()
-                val agentMaps = activeAgents.associateBy { it.agentId }
-
-                val preBuildAgents = HashSet<ThirdPartyAgent>()
-                thirdPartyAgentBuildService.getPreBuildAgents(
-                    projectId = event.projectId,
-                    pipelineId = event.pipelineId,
-                    vmSeqId = event.vmSeqId
-                ).forEach {
-                    val agent = agentMaps[it.agentId]
-                    if (agent != null) {
-                        preBuildAgents.add(agent)
-                    }
                 }
-
-                val hasTryAgents = HashSet<String>()
-                val runningBuildsMapper = HashMap<String/*AgentId*/, Int/*running builds*/>()
-                // docker和二进制任务区分开，所以单独设立一个
-                val dockerRunningBuildsMapper = HashMap<String/*AgentId*/, Int/*running builds*/>()
-
-                /**
-                 * 1. 最高优先级的agent:
-                 *     a. 最近构建机中使用过这个构建机
-                 *     b. 当前没有任何构建机任务
-                 * 2. 次高优先级的agent:
-                 *     a. 最近构建机中使用过这个构建机
-                 *     b. 当前有构建任务，但是构建任务数量没有达到当前构建机的最大并发数
-                 * 3. 第三优先级的agent:
-                 *     a. 当前没有任何构建机任务
-                 * 4. 第四优先级的agent:
-                 *     a. 当前有构建任务，但是构建任务数量没有达到当前构建机的最大并发数
-                 * 5. 最低优先级：
-                 *     a. 都没有满足以上条件的
-                 *
-                 */
-
-                /**
-                 * 根据哪些agent没有任何任务并且是在最近构建中使用到的Agent
-                 */
-                logDebug(
-                    buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
-                            I18nUtil.getCodeLanMessage(
-                                messageCode = BK_SEARCHING_AGENT,
-                                language = I18nUtil.getDefaultLocaleLanguage()
-                            )
-                )
-                if (startEmptyAgents(
-                        event = event,
-                        dispatchType = dispatchType,
-                        agents = preBuildAgents,
-                        hasTryAgents = hasTryAgents,
-                        runningBuildsMapper = runningBuildsMapper,
-                        dockerRunningBuildsMapper = dockerRunningBuildsMapper
-                    )
-                ) {
-                    logger.info(
-                        "${event.buildId}|START_AGENT|" +
-                                "j(${event.vmSeqId})|dispatchType=$dispatchType|get preBuildAgents"
-                    )
-                    return
-                }
-
-                logger.info(
-                    "[${event.projectId}|${event.pipelineId}|" +
-                            "${event.buildId}|${event.vmSeqId}]" +
-                            " Start to check the available task agents of pre build agents"
-                )
-                logDebug(
-                    buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
-                            I18nUtil.getCodeLanMessage(
-                                messageCode = BK_MAX_BUILD_SEARCHING_AGENT,
-                                language = I18nUtil.getDefaultLocaleLanguage()
-                            )
-                )
-                /**
-                 * 根据哪些agent有任务并且是在最近构建中使用到的Agent，同时当前构建任务还没到达该Agent最大并行数
-                 */
-                if (startAvailableAgents(
-                        event = event,
-                        dispatchType = dispatchType,
-                        agents = preBuildAgents,
-                        hasTryAgents = hasTryAgents,
-                        runningBuildsMapper = runningBuildsMapper,
-                        dockerRunningBuildsMapper = dockerRunningBuildsMapper
-                    )
-                ) {
-                    logger.info(
-                        "${event.buildId}|START_AGENT|" +
-                                "j(${event.vmSeqId})|dispatchType=$dispatchType|get Available preBuildAgents"
-                    )
-                    return
-                }
-
-                logDebug(
-                    buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
-                            I18nUtil.getCodeLanMessage(
-                                messageCode = BK_SEARCHING_AGENT_MOST_IDLE,
-                                language = I18nUtil.getDefaultLocaleLanguage()
-                            )
-                )
-                /**
-                 * 根据哪些agent没有任何任务
-                 */
-                if (startEmptyAgents(
-                        event = event,
-                        dispatchType = dispatchType,
-                        agents = activeAgents,
-                        hasTryAgents = hasTryAgents,
-                        runningBuildsMapper = runningBuildsMapper,
-                        dockerRunningBuildsMapper = dockerRunningBuildsMapper
-                    )
-                ) {
-                    logger.info(
-                        "${event.buildId}|START_AGENT|" +
-                                "j(${event.vmSeqId})|dispatchType=$dispatchType|get activeAgents"
-                    )
-                    return
-                }
-
-                logDebug(
-                    buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
-                            I18nUtil.getCodeLanMessage(
-                                messageCode = BK_SEARCHING_AGENT_PARALLEL_AVAILABLE,
-                                language = I18nUtil.getDefaultLocaleLanguage()
-                            )
-                )
-                /**
-                 * 根据哪些agent有任务，同时当前构建任务还没到达该Agent最大并行数
-                 */
-                if (startAvailableAgents(
-                        event = event,
-                        dispatchType = dispatchType,
-                        agents = activeAgents,
-                        hasTryAgents = hasTryAgents,
-                        runningBuildsMapper = runningBuildsMapper,
-                        dockerRunningBuildsMapper = dockerRunningBuildsMapper
-                    )
-                ) {
-                    logger.info(
-                        "${event.buildId}|START_AGENT|" +
-                                "j(${event.vmSeqId})|dispatchType=$dispatchType|get Available activeAgents"
-                    )
-                    return
-                }
-
-                if (event.retryTime == 1) {
-                    log(
-                        buildLogPrinter,
-                        event,
-                        message = I18nUtil.getCodeLanMessage(
-                        messageCode = BK_NO_AGENT_AVAILABLE,
-                        language = I18nUtil.getDefaultLocaleLanguage()
-                        )
-                    )
-                }
+                // 没有可用构建机列表进入下一次重试, 修复获取最近构建构建机超过10次不构建会被驱逐出最近构建机列表的BUG
+                if (activeAgents.isNotEmpty() && pickupAgent(activeAgents, event, dispatchType)) return
             } else {
                 log(
                     buildLogPrinter,
@@ -644,9 +492,145 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                             params = arrayOf("${event.queueTimeoutMinutes}")
                         )
             )
-        } finally {
-            redisLock.unlock()
         }
+    }
+
+    private fun pickupAgent(
+        activeAgents: List<ThirdPartyAgent>,
+        event: PipelineAgentStartupEvent,
+        dispatchType: ThirdPartyAgentEnvDispatchType
+    ): Boolean {
+        val agentMaps = activeAgents.associateBy { it.agentId }
+
+        val preBuildAgents = ArrayList<ThirdPartyAgent>(agentMaps.size)
+        thirdPartyAgentBuildService.getPreBuildAgentIds(
+            projectId = event.projectId,
+            pipelineId = event.pipelineId,
+            vmSeqId = event.vmSeqId,
+            size = activeAgents.size.coerceAtLeast(1)
+        ).forEach { agentId -> agentMaps[agentId]?.let { agent -> preBuildAgents.add(agent) } }
+
+        val hasTryAgents = HashSet<String>()
+        val runningBuildsMapper = HashMap<String/*AgentId*/, Int/*running builds*/>()
+        // docker和二进制任务区分开，所以单独设立一个
+        val dockerRunningBuildsMapper = HashMap<String/*AgentId*/, Int/*running builds*/>()
+
+        /**
+         * 1. 最高优先级的agent:
+         *     a. 最近构建机中使用过这个构建机
+         *     b. 当前没有任何构建机任务
+         * 2. 次高优先级的agent:
+         *     a. 最近构建机中使用过这个构建机
+         *     b. 当前有构建任务，但是构建任务数量没有达到当前构建机的最大并发数
+         * 3. 第三优先级的agent:
+         *     a. 当前没有任何构建机任务
+         * 4. 第四优先级的agent:
+         *     a. 当前有构建任务，但是构建任务数量没有达到当前构建机的最大并发数
+         */
+
+        /**
+         * 根据哪些agent没有任何任务并且是在最近构建中使用到的Agent
+         */
+        logDebug(
+            buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
+                    I18nUtil.getCodeLanMessage(
+                        messageCode = BK_SEARCHING_AGENT,
+                        language = I18nUtil.getDefaultLocaleLanguage()
+                    )
+        )
+        if (startEmptyAgents(
+                event = event,
+                dispatchType = dispatchType,
+                agents = preBuildAgents,
+                hasTryAgents = hasTryAgents,
+                runningBuildsMapper = runningBuildsMapper,
+                dockerRunningBuildsMapper = dockerRunningBuildsMapper
+            )
+        ) {
+            logger.info("${event.buildId}|START_AGENT|j(${event.vmSeqId})|dispatchType=$dispatchType|Get Lv.1")
+            return true
+        }
+
+        logDebug(
+            buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
+                    I18nUtil.getCodeLanMessage(
+                        messageCode = BK_MAX_BUILD_SEARCHING_AGENT,
+                        language = I18nUtil.getDefaultLocaleLanguage()
+                    )
+        )
+        /**
+         * 根据哪些agent有任务并且是在最近构建中使用到的Agent，同时当前构建任务还没到达该Agent最大并行数
+         */
+        if (startAvailableAgents(
+                event = event,
+                dispatchType = dispatchType,
+                agents = preBuildAgents,
+                hasTryAgents = hasTryAgents,
+                runningBuildsMapper = runningBuildsMapper,
+                dockerRunningBuildsMapper = dockerRunningBuildsMapper
+            )
+        ) {
+            logger.info("${event.buildId}|START_AGENT|j(${event.vmSeqId})|dispatchType=$dispatchType|Get Lv.2")
+            return true
+        }
+
+        logDebug(
+            buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
+                    I18nUtil.getCodeLanMessage(
+                        messageCode = BK_SEARCHING_AGENT_MOST_IDLE,
+                        language = I18nUtil.getDefaultLocaleLanguage()
+                    )
+        )
+        /**
+         * 根据哪些agent没有任何任务
+         */
+        if (startEmptyAgents(
+                event = event,
+                dispatchType = dispatchType,
+                agents = activeAgents,
+                hasTryAgents = hasTryAgents,
+                runningBuildsMapper = runningBuildsMapper,
+                dockerRunningBuildsMapper = dockerRunningBuildsMapper
+            )
+        ) {
+            logger.info("${event.buildId}|START_AGENT|j(${event.vmSeqId})|dispatchType=$dispatchType|pickup Lv.3")
+            return true
+        }
+
+        logDebug(
+            buildLogPrinter, event, message = "retry: ${event.retryTime} | " +
+                    I18nUtil.getCodeLanMessage(
+                        messageCode = BK_SEARCHING_AGENT_PARALLEL_AVAILABLE,
+                        language = I18nUtil.getDefaultLocaleLanguage()
+                    )
+        )
+        /**
+         * 根据哪些agent有任务，同时当前构建任务还没到达该Agent最大并行数
+         */
+        if (startAvailableAgents(
+                event = event,
+                dispatchType = dispatchType,
+                agents = activeAgents,
+                hasTryAgents = hasTryAgents,
+                runningBuildsMapper = runningBuildsMapper,
+                dockerRunningBuildsMapper = dockerRunningBuildsMapper
+            )
+        ) {
+            logger.info("${event.buildId}|START_AGENT|j(${event.vmSeqId})|dispatchType=$dispatchType|Get Lv.4")
+            return true
+        }
+
+        if (event.retryTime == 1) {
+            log(
+                buildLogPrinter = buildLogPrinter,
+                event = event,
+                message = I18nUtil.getCodeLanMessage(
+                    messageCode = BK_NO_AGENT_AVAILABLE,
+                    language = I18nUtil.getDefaultLocaleLanguage()
+                )
+            )
+        }
+        return false
     }
 
     override fun retry(
@@ -670,12 +654,13 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
             return
         }
         logDebug(
-            buildLogPrinter,
-            event,
-            I18nUtil.getCodeLanMessage(
+            buildLogPrinter = buildLogPrinter,
+            event = event,
+            message = I18nUtil.getCodeLanMessage(
                 messageCode = BK_AGENT_IS_BUSY,
                 language = I18nUtil.getDefaultLocaleLanguage()
-            ) + " - retry: ${event.retryTime + 1}")
+            ) + " - retry: ${event.retryTime + 1}"
+        )
 
         event.retryTime += 1
         event.delayMills = 10000
@@ -685,7 +670,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
     private fun startEmptyAgents(
         event: PipelineAgentStartupEvent,
         dispatchType: ThirdPartyAgentEnvDispatchType,
-        agents: HashSet<ThirdPartyAgent>,
+        agents: Collection<ThirdPartyAgent>,
         hasTryAgents: HashSet<String>,
         runningBuildsMapper: HashMap<String, Int>,
         dockerRunningBuildsMapper: HashMap<String, Int>
@@ -716,7 +701,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
     private fun startAvailableAgents(
         event: PipelineAgentStartupEvent,
         dispatchType: ThirdPartyAgentEnvDispatchType,
-        agents: HashSet<ThirdPartyAgent>,
+        agents: Collection<ThirdPartyAgent>,
         hasTryAgents: HashSet<String>,
         runningBuildsMapper: HashMap<String, Int>,
         dockerRunningBuildsMapper: HashMap<String, Int>
@@ -736,36 +721,30 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                     dockerRunningCnt: Int
                 ): Boolean {
                     if (dockerBuilder) {
-                        if (agent.dockerParallelTaskCount != null &&
-                            agent.dockerParallelTaskCount!! > 0 &&
-                            agent.dockerParallelTaskCount!! > dockerRunningCnt
-                        ) {
-                            return true
-                        }
-                        return false
+                        return agent.dockerParallelTaskCount != null &&
+                                agent.dockerParallelTaskCount!! > 0 &&
+                                agent.dockerParallelTaskCount!! > dockerRunningCnt
                     }
-                    if (agent.parallelTaskCount != null &&
-                        agent.parallelTaskCount!! > 0 &&
-                        agent.parallelTaskCount!! > runningCnt
-                    ) {
-                        return true
-                    }
-                    return false
+                    return agent.parallelTaskCount != null &&
+                            agent.parallelTaskCount!! > 0 &&
+                            agent.parallelTaskCount!! > runningCnt
                 }
             }
         )
     }
 
+    @Suppress("NestedBlockDepth")
     private fun startAgentsForEnvBuild(
         event: PipelineAgentStartupEvent,
         dispatchType: ThirdPartyAgentEnvDispatchType,
-        agents: HashSet<ThirdPartyAgent>,
+        agents: Collection<ThirdPartyAgent>,
         hasTryAgents: HashSet<String>,
         runningBuildsMapper: HashMap<String, Int>,
         dockerRunningBuildsMapper: HashMap<String, Int>,
         agentMatcher: AgentMatcher
     ): Boolean {
         if (agents.isNotEmpty()) {
+            val sortQ = mutableListOf<Triple<ThirdPartyAgent, Int/*runningCnt*/, Int/*dockerRunningCnt*/>>()
             agents.forEach {
                 if (hasTryAgents.contains(it.agentId)) {
                     return@forEach
@@ -776,16 +755,22 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
                 } else {
                     getDockerRunningCnt(it.agentId, dockerRunningBuildsMapper)
                 }
+                sortQ.add(Triple(it, runningCnt, dockerRunningCnt))
+            }
+
+            // 当前正在运行任务少升序开始遍历(通常任务少是负载最低,但不完全是,负载取决于构建机上运行的任务大小,目前未有采集,先只按任务数来判断)
+            sortQ.sortedBy { it.second + it.third }.forEach {
                 if (agentMatcher.match(
-                        runningCnt = runningCnt,
-                        agent = it,
+                        agent = it.first,
+                        runningCnt = it.second,
                         dockerBuilder = dispatchType.dockerInfo != null,
-                        dockerRunningCnt = dockerRunningCnt
+                        dockerRunningCnt = it.third
                     )
                 ) {
-                    if (startEnvAgentBuild(event, it, dispatchType, hasTryAgents)) {
+                    val agent = it .first
+                    if (startEnvAgentBuild(event, agent, dispatchType, hasTryAgents)) {
                         logger.info(
-                            "[${it.projectId}|$[${event.pipelineId}|${event.buildId}|${it.agentId}] " +
+                            "[${event.projectId}|$[${event.pipelineId}|${event.buildId}|${agent.agentId}] " +
                                     "Success to start the build"
                         )
                         return true
@@ -806,10 +791,7 @@ class ThirdPartyAgentDispatcher @Autowired constructor(
             return false
         }
         hasTryAgents.add(agent.agentId)
-        if (buildByAgentId(event, agent, dispatchType.workspace, dispatchType.dockerInfo)) {
-            return true
-        }
-        return false
+        return buildByAgentId(event, agent, dispatchType.workspace, dispatchType.dockerInfo)
     }
 
     private fun getRunningCnt(agentId: String, runningBuildsMapper: HashMap<String, Int>): Int {

--- a/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/utils/ThirdPartyAgentEnvLock.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/utils/ThirdPartyAgentEnvLock.kt
@@ -36,7 +36,7 @@ class ThirdPartyAgentEnvLock(
     redisOperation: RedisOperation,
     projectId: String,
     envId: String
-) {
+): AutoCloseable {
 
     private val redisLock = RedisLock(redisOperation, "DISPATCH_REDIS_LOCK_ENV_${projectId}_$envId", 60L)
 
@@ -54,4 +54,7 @@ class ThirdPartyAgentEnvLock(
     fun lock() = redisLock.lock()
 
     fun unlock() = redisLock.unlock()
+    override fun close() {
+        unlock()
+    }
 }

--- a/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/utils/ThirdPartyAgentEnvLock.kt
+++ b/src/backend/ci/core/dispatch/biz-dispatch/src/main/kotlin/com/tencent/devops/dispatch/utils/ThirdPartyAgentEnvLock.kt
@@ -36,25 +36,20 @@ class ThirdPartyAgentEnvLock(
     redisOperation: RedisOperation,
     projectId: String,
     envId: String
-): AutoCloseable {
-
-    private val redisLock = RedisLock(redisOperation, "DISPATCH_REDIS_LOCK_ENV_${projectId}_$envId", 60L)
+) : RedisLock(
+    redisOperation = redisOperation,
+    lockKey = "DISPATCH_REDIS_LOCK_ENV_${projectId}_$envId",
+    expiredTimeInSeconds = 60L
+) {
 
     fun tryLock(timeout: Long = 1000, interval: Long = 100): Boolean {
-        val sleep = min(interval, timeout) // 不允许sleep过长时间，最大1000ms
+        val sleepTime = min(interval, timeout) // sleep时间不超过timeout
         val start = System.currentTimeMillis()
-        var tryLock = redisLock.tryLock()
+        var tryLock = tryLock()
         while (timeout > 0 && !tryLock && timeout > (System.currentTimeMillis() - start)) {
-            Thread.sleep(sleep)
-            tryLock = redisLock.tryLock()
+            Thread.sleep(sleepTime)
+            tryLock = tryLock()
         }
         return tryLock
-    }
-
-    fun lock() = redisLock.lock()
-
-    fun unlock() = redisLock.unlock()
-    override fun close() {
-        unlock()
     }
 }


### PR DESCRIPTION
#9101
- [x] 优化构建[StartActionTaskContainerCmd]提前条件判断是否会有任务执行,如没有,则不需要调度

- [x] 修复获取最近私有构建集群中构建机超过10次不构建的会被驱逐出最近构建机列表的BUG[ThirdPartyAgentBuildDao] 

- [x] 因调度上提示信息的频繁读取国际化, 做了缓存上优化[BkI18nLanguageCacheUtil],  并解决页面上切换的缓存依赖[I18nUtil], 从前端页面传入的cookie中读取并做转换.

- [x] 对于次高优先和第四优先级 ,优化根据任务数量进行平均调度,不全打到一台机器上[ThirdPartyAgentDispatcher].(见粗体)
  - 2.次高优先级的构建机:
      - a. 最近构建机中使用过这个构建机, 并且
      - **b. 当前有构建任务,选当前正在运行任务最少的构建机(没有达到当前构建机的最大并发数)**
  - 4.第四优先级的构建机:
      - **a. 当前有构建任务,选当前正在运行任务最少的构建机(没有达到当前构建机的最大并发数)**

<img width="1522" alt="企业微信截图_9d2c96a5-45c6-45f5-90d5-e6f8484ab59a" src="https://github.com/TencentBlueKing/bk-ci/assets/16686129/4e0731fa-79dc-4617-982f-6f013327e4f5">
