### PR TITLE
缩减process微服务的子模块数量 #9307

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/config/MeasureConfig.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/config/MeasureConfig.kt
@@ -1,8 +1,9 @@
 package com.tencent.devops.process.config
 
+import com.tencent.devops.common.web.mq.EXTEND_RABBIT_TEMPLATE_NAME
 import com.tencent.devops.process.service.measure.MeasureEventDispatcher
 import org.springframework.amqp.rabbit.core.RabbitTemplate
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -11,7 +12,7 @@ class MeasureConfig {
 
     @Bean
     fun measureEventDispatcher(
-        @Autowired extendRabbitTemplate: RabbitTemplate
+        @Qualifier(EXTEND_RABBIT_TEMPLATE_NAME) extendRabbitTemplate: RabbitTemplate
     ): MeasureEventDispatcher =
         MeasureEventDispatcher(extendRabbitTemplate)
 }

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildMonitorControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildMonitorControl.kt
@@ -235,14 +235,14 @@ class BuildMonitorControl @Autowired constructor(
         val minute = controlOption.jobControlOption.timeout
         val timeoutMills = Timeout.transMinuteTimeoutToMills(minute)
 
-        buildLogPrinter.addDebugLine(
-            buildId = buildId,
-            message = "[SystemLog]Check job timeout($minute minutes), " +
-                "running: ${TimeUnit.MILLISECONDS.toMinutes(usedTimeMills)} minutes!",
-            tag = VMUtils.genStartVMTaskId(containerId),
-            jobId = containerHashId,
-            executeCount = executeCount
-        )
+//        buildLogPrinter.addDebugLine(
+//            buildId = buildId,
+//            message = "[SystemLog]Check job timeout($minute minutes), " +
+//                "running: ${TimeUnit.MILLISECONDS.toMinutes(usedTimeMills)} minutes!",
+//            tag = VMUtils.genStartVMTaskId(containerId),
+//            jobId = containerHashId,
+//            executeCount = executeCount
+//        )
 
         val interval = timeoutMills - usedTimeMills
         if (interval <= 0) {
@@ -326,14 +326,14 @@ class BuildMonitorControl @Autowired constructor(
             0
         }
 
-        buildLogPrinter.addDebugLine(
-            buildId = buildId,
-            message = "Monitor| check stage review($inOrOut) timeout($hours hours), " +
-                "running: ${TimeUnit.MILLISECONDS.toMinutes(usedTimeMills)}) minutes!",
-            tag = stageId,
-            jobId = "",
-            executeCount = executeCount
-        )
+//        buildLogPrinter.addDebugLine(
+//            buildId = buildId,
+//            message = "Monitor| check stage review($inOrOut) timeout($hours hours), " +
+//                "running: ${TimeUnit.MILLISECONDS.toMinutes(usedTimeMills)}) minutes!",
+//            tag = stageId,
+//            jobId = "",
+//            executeCount = executeCount
+//        )
 
         val interval = timeoutMills - usedTimeMills
         if (interval <= 0) {
@@ -402,10 +402,10 @@ class BuildMonitorControl @Autowired constructor(
             val jobId = "0"
             buildLogPrinter.addRedLine(
                 buildId = event.buildId,
-                message = errorInfo.message ?: I18nUtil.getCodeLanMessage(
+                message = errorInfo.message ?: (I18nUtil.getCodeLanMessage(
                     messageCode = BK_QUEUE_TIMEOUT,
                     language = I18nUtil.getDefaultLocaleLanguage()
-                ) + ". Cancel build!",
+                ) + ". Cancel build!"),
                 tag = VMUtils.genStartVMTaskId(jobId),
                 jobId = jobId,
                 executeCount = 1

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/init/BuildEngineCoreTaskConfiguration.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/init/BuildEngineCoreTaskConfiguration.kt
@@ -29,7 +29,6 @@ package com.tencent.devops.process.engine.init
 
 import com.tencent.devops.common.event.dispatcher.pipeline.mq.MQ
 import com.tencent.devops.common.event.dispatcher.pipeline.mq.Tools
-import com.tencent.devops.common.service.utils.CommonUtils
 import com.tencent.devops.process.engine.listener.run.PipelineAtomTaskBuildListener
 import com.tencent.devops.process.engine.listener.run.PipelineTaskPauseListener
 import org.springframework.amqp.core.Binding
@@ -90,44 +89,44 @@ class BuildEngineCoreTaskConfiguration {
             maxConcurrency = 50
         )
     }
+//
+//    /**
+//     * 本机专属任务队列
+//     */
+//    @Bean
+//    fun localPipelineBuildTaskQueue() = Queue(MQ.QUEUE_PIPELINE_BUILD_TASK_START + CommonUtils.getInnerIP())
+//
+//    @Bean
+//    fun localPipelineBuildTaskQueueBind(
+//        @Autowired localPipelineBuildTaskQueue: Queue,
+//        @Autowired pipelineCoreExchange: DirectExchange
+//    ): Binding {
+//        return BindingBuilder.bind(localPipelineBuildTaskQueue)
+//            .to(pipelineCoreExchange)
+//            .with(MQ.ROUTE_PIPELINE_BUILD_TASK_START + CommonUtils.getInnerIP())
+//    }
 
-    /**
-     * 本机专属任务队列
-     */
-    @Bean
-    fun localPipelineBuildTaskQueue() = Queue(MQ.QUEUE_PIPELINE_BUILD_TASK_START + CommonUtils.getInnerIP())
-
-    @Bean
-    fun localPipelineBuildTaskQueueBind(
-        @Autowired localPipelineBuildTaskQueue: Queue,
-        @Autowired pipelineCoreExchange: DirectExchange
-    ): Binding {
-        return BindingBuilder.bind(localPipelineBuildTaskQueue)
-            .to(pipelineCoreExchange)
-            .with(MQ.ROUTE_PIPELINE_BUILD_TASK_START + CommonUtils.getInnerIP())
-    }
-
-    @Bean
-    fun localPipelineAtomTaskBuildListenerContainer(
-        @Autowired connectionFactory: ConnectionFactory,
-        @Autowired localPipelineBuildTaskQueue: Queue,
-        @Autowired rabbitAdmin: RabbitAdmin,
-        @Autowired buildListener: PipelineAtomTaskBuildListener,
-        @Autowired messageConverter: Jackson2JsonMessageConverter
-    ): SimpleMessageListenerContainer {
-
-        return Tools.createSimpleMessageListenerContainer(
-            connectionFactory = connectionFactory,
-            queue = localPipelineBuildTaskQueue,
-            rabbitAdmin = rabbitAdmin,
-            buildListener = buildListener,
-            messageConverter = messageConverter,
-            startConsumerMinInterval = 5000,
-            consecutiveActiveTrigger = 1,
-            concurrency = 1,
-            maxConcurrency = 50
-        )
-    }
+//    @Bean
+//    fun localPipelineAtomTaskBuildListenerContainer(
+//        @Autowired connectionFactory: ConnectionFactory,
+//        @Autowired localPipelineBuildTaskQueue: Queue,
+//        @Autowired rabbitAdmin: RabbitAdmin,
+//        @Autowired buildListener: PipelineAtomTaskBuildListener,
+//        @Autowired messageConverter: Jackson2JsonMessageConverter
+//    ): SimpleMessageListenerContainer {
+//
+//        return Tools.createSimpleMessageListenerContainer(
+//            connectionFactory = connectionFactory,
+//            queue = localPipelineBuildTaskQueue,
+//            rabbitAdmin = rabbitAdmin,
+//            buildListener = buildListener,
+//            messageConverter = messageConverter,
+//            startConsumerMinInterval = 5000,
+//            consecutiveActiveTrigger = 1,
+//            concurrency = 1,
+//            maxConcurrency = 50
+//        )
+//    }
 
     /**
      * 流水线暂停操作队列


### PR DESCRIPTION
删除ip专属队列,无用,在容器化环境还会导致因pod重启(ip重新分配)出现无主队列