### PR TITLE
bug: 点击人工审核会把流水线中同一条红线规则的两处控制点的数据都刷新，导致另一个控制点的审核失败 #9633

### DIFF
--- a/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/dao/HistoryDao.kt
+++ b/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/dao/HistoryDao.kt
@@ -281,6 +281,18 @@ class HistoryDao @Autowired constructor(
         return count(dslContext, projectId, pipelineId, ruleId, RuleInterceptResult.FAIL.name, startTime, endTime)
     }
 
+    fun batchUpdateHistoryResultById(
+        historyIds: Set<Long>,
+        result: RuleInterceptResult
+    ): Int {
+        return with(THistory.T_HISTORY) {
+            innerDslContext.update(this)
+                .set(RESULT, result.name)
+                .where(ID.`in`(historyIds))
+                .execute()
+        }
+    }
+
     fun batchUpdateHistoryResult(
         projectId: String,
         pipelineId: String,

--- a/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/listener/PipelineBuildQualityListener.kt
+++ b/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/listener/PipelineBuildQualityListener.kt
@@ -196,7 +196,7 @@ class PipelineBuildQualityListener @Autowired constructor(
             val pipelineId = event.pipelineId
             val buildId = event.buildId
             val ruleIds = event.ruleIds.map { HashUtil.decodeIdToLong(it) }.toSet()
-            val historyIdList = mutableListOf<Long>()
+            val historyIdSet = mutableSetOf<Long>()
             val history = qualityHistoryService.batchServiceList(
                 projectId = projectId,
                 pipelineId = pipelineId,
@@ -212,12 +212,12 @@ class PipelineBuildQualityListener @Autowired constructor(
             history.groupBy { it.ruleId }.forEach { (ruleId, list) ->
                 val historyId = list.findLast { it.ruleId == ruleId }?.id
                 if (historyId != null) {
-                    historyIdList.add(historyId)
+                    historyIdSet.add(historyId)
                 }
             }
-            logger.info("QUALITY|update history id: ${historyIdList.toSet()}")
+            logger.info("QUALITY|[${event.buildId}]update history id: $historyIdSet")
             val count = qualityHistoryDao.batchUpdateHistoryResultById(
-                historyIds = historyIdList.toSet(),
+                historyIds = historyIdSet,
                 result = action
             )
             logger.info("QUALITY|[${event.buildId}]history result update count: $count")

--- a/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/listener/PipelineBuildQualityListener.kt
+++ b/src/backend/ci/core/quality/biz-quality/src/main/kotlin/com/tencent/devops/quality/listener/PipelineBuildQualityListener.kt
@@ -40,6 +40,7 @@ import com.tencent.devops.quality.dao.HistoryDao
 import com.tencent.devops.quality.dao.v2.QualityHisMetadataDao
 import com.tencent.devops.quality.dao.v2.QualityRuleBuildHisDao
 import com.tencent.devops.quality.dao.v2.QualityRuleReviewerDao
+import com.tencent.devops.quality.service.v2.QualityHistoryService
 import org.jooq.DSLContext
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.core.ExchangeTypes
@@ -57,7 +58,8 @@ class PipelineBuildQualityListener @Autowired constructor(
     private val qualityRuleBuildHisDao: QualityRuleBuildHisDao,
     private val qualityHistoryDao: HistoryDao,
     private val qualityRuleReviewerDao: QualityRuleReviewerDao,
-    private val qualityHisMetadataDao: QualityHisMetadataDao
+    private val qualityHisMetadataDao: QualityHisMetadataDao,
+    private val qualityHistoryService: QualityHistoryService
 ) {
 
     companion object {
@@ -194,12 +196,29 @@ class PipelineBuildQualityListener @Autowired constructor(
             val pipelineId = event.pipelineId
             val buildId = event.buildId
             val ruleIds = event.ruleIds.map { HashUtil.decodeIdToLong(it) }.toSet()
-            val count = qualityHistoryDao.batchUpdateHistoryResult(
+            val historyIdList = mutableListOf<Long>()
+            val history = qualityHistoryService.batchServiceList(
                 projectId = projectId,
                 pipelineId = pipelineId,
                 buildId = buildId,
-                result = action,
-                ruleIds = ruleIds
+                ruleIds = ruleIds,
+                result = RuleInterceptResult.WAIT.name,
+                checkTimes = null,
+                startTime = null,
+                endTime = null,
+                offset = null,
+                limit = null
+            )
+            history.groupBy { it.ruleId }.forEach { (ruleId, list) ->
+                val historyId = list.findLast { it.ruleId == ruleId }?.id
+                if (historyId != null) {
+                    historyIdList.add(historyId)
+                }
+            }
+            logger.info("QUALITY|update history id: ${historyIdList.toSet()}")
+            val count = qualityHistoryDao.batchUpdateHistoryResultById(
+                historyIds = historyIdList.toSet(),
+                result = action
             )
             logger.info("QUALITY|[${event.buildId}]history result update count: $count")
 


### PR DESCRIPTION
bug: 点击人工审核会把流水线中同一条红线规则的两处控制点的数据都刷新，导致另一个控制点的审核失败 #9633