### PR TITLE
bug: 重命名代码库以后, 使用旧别名关联代码库会报错 #9984

### DIFF
--- a/src/backend/ci/core/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/service/RepositoryService.kt
+++ b/src/backend/ci/core/repository/biz-repository/src/main/kotlin/com/tencent/devops/repository/service/RepositoryService.kt
@@ -1140,6 +1140,8 @@ class RepositoryService @Autowired constructor(
             hashId = repositoryHashId,
             newName = repoRename.name
         )
+        // 同步权限中心
+        editResource(projectId, repositoryId, repoRename.name)
     }
 
     companion object {


### PR DESCRIPTION
#9984 