### PR TITLE
perf: 插件执行错误码优化 #10326

### DIFF
--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineContainerService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineContainerService.kt
@@ -485,7 +485,7 @@ class PipelineContainerService @Autowired constructor(
                 }
                 needUpdateContainer = true
             } else {
-                // 如果是失败的插件重试，并且当前插件不是要重试或跳过的插件，则检查其之前的状态，如果已经执行过，则跳过
+                // 如果是失败的插件重试，并且当前插件不是要重试或跳过的插件，则检查其之前的状态，如果已经执行过，则跳过（取消状态除外）
                 if (context.needSkipTaskWhenRetry(stage, container, atomElement.id)) {
                     val target = findLastTimeBuildTask(
                         lastTimeBuildTasks = lastTimeBuildTasks,
@@ -494,8 +494,9 @@ class PipelineContainerService @Autowired constructor(
                     )
                     // 插件任务在历史中找不到，则跳过当前插件
                     // 如果插件任务之前已经是完成状态，则跳过当前插件
+                    // 如果是取消状态的，则不能跳过，取消状态属于要重试再次执行的状态（比如重试的是checkout插件，其post-action如是取消)
                     try {
-                        if (target == null || target.status.isFinish()) {
+                        if (target == null || (target.status.isFinish() && !target.status.isCancel())) {
                             return@nextElement
                         }
                     } catch (ignored: Exception) { // 如果存在异常的ordinal

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/market/MarketAtomTask.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/market/MarketAtomTask.kt
@@ -518,7 +518,6 @@ open class MarketAtomTask : ITask() {
     private fun getAtomSensitiveConfMap(atomCode: String): Map<String, MutableMap<String, String>> {
         // 查询插件的敏感信息
         val atomSensitiveConfResult = atomApi.getAtomSensitiveConf(atomCode)
-        logger.info("atomCode is:$atomCode ,atomSensitiveConfResult is:$atomSensitiveConfResult")
         val atomSensitiveConfList = atomSensitiveConfResult.data
         val atomSensitiveConfMap = mutableMapOf<String, String>()
         atomSensitiveConfList?.forEach {


### PR DESCRIPTION
1、取消构建的再重试时如果是取消状态的，则不能跳过，取消状态属于要重试再次执行的状态（比如重试的是checkout插件，其post-action如是取消)