### PR TITLE
【蓝盾-产品-已评审】流水线支持展示运行进度 #7932 fix

### DIFF
--- a/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
+++ b/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
@@ -1,0 +1,118 @@
+package com.tencent.devops.worker.common.utils
+
+import java.io.File
+import java.security.AccessController
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import sun.security.action.GetPropertyAction
+
+
+class CommandLineUtilsTest {
+
+    @Test
+    fun reportProgressRateTest() {
+        fun func(str: String) = CommandLineUtils.reportProgressRate("test", str)
+        /*不识别*/
+        Assertions.assertEquals(func("echo \"::set-progress-rate 0.3758\""), null)
+        Assertions.assertEquals(func("echo '::set-progress-rate 0.3758'"), null)
+        Assertions.assertEquals(func("echo ::set-progress-rate 0.3758"), null)
+        Assertions.assertEquals(func("print(\"::set-progress-rate 0.3758\")"), null)
+        /*多空格*/
+        Assertions.assertEquals(func(" ::set-progress-rate 0.3758"), null)
+        /*windows兼容*/
+        Assertions.assertEquals(func("\"::set-progress-rate 0.3758\""), 0.3758)
+        /*默认*/
+        Assertions.assertEquals(func("::set-progress-rate 0.3758"), 0.3758)
+    }
+
+    @Test
+    fun appendVariableToFileTest() {
+        fun func(str: String) = CommandLineUtils.appendVariableToFile(str, File(
+            AccessController
+                .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+        ), "appendVariableToFileTest")
+        /*不识别*/
+        Assertions.assertEquals(func("echo \"::set-variable name=RESULT::test\""), null)
+        Assertions.assertEquals(func("echo '::set-variable name=RESULT::test'"), null)
+        Assertions.assertEquals(func("echo ::set-variable name=RESULT::test"), null)
+        Assertions.assertEquals(func("print(\"::set-variable name=RESULT::test\")"), null)
+        /*多空格*/
+        Assertions.assertEquals(func(" ::set-variable name=RESULT::test"), null)
+        /*windows兼容*/
+        Assertions.assertEquals(func("\"::set-variable name=RESULT::test\""), "variables.RESULT=test\n")
+        /*默认*/
+        Assertions.assertEquals(func("::set-variable name=RESULT::test"), "variables.RESULT=test\n")
+    }
+
+    @Test
+    fun appendRemarkToFileTest() {
+        fun func(str: String) = CommandLineUtils.appendRemarkToFile(str, File(
+            AccessController
+                .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+        ), "appendRemarkToFileTest")
+        /*不识别*/
+        Assertions.assertEquals(func("echo \"::set-remark 备注信息\""), null)
+        Assertions.assertEquals(func("echo '::set-remark 备注信息'"), null)
+        Assertions.assertEquals(func("echo ::set-remark 备注信息"), null)
+        Assertions.assertEquals(func("print(\"::set-remark 备注信息\")"), null)
+        /*多空格*/
+        Assertions.assertEquals(func(" ::set-remark 备注信息"), null)
+        /*windows兼容*/
+        Assertions.assertEquals(func("\"::set-remark 备注信息\""), "BK_CI_BUILD_REMARK=备注信息\n")
+        /*默认*/
+        Assertions.assertEquals(func("::set-remark 备注信息"), "BK_CI_BUILD_REMARK=备注信息\n")
+    }
+
+
+    @Test
+    fun appendOutputToFileTest() {
+        val jobId = "job_xx"
+        val stepId = "step_xx"
+        fun func(str: String) = CommandLineUtils.appendOutputToFile(
+            tmpLine = str,
+            workspace = File(
+                AccessController
+                    .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+            ),
+            resultLogFile = "appendOutputToFileTest",
+            jobId = jobId,
+            stepId = stepId
+        )
+        /*不识别*/
+        Assertions.assertEquals(func("echo \"::set-output name=RESULT::test\""), null)
+        Assertions.assertEquals(func("echo '::set-output name=RESULT::test'"), null)
+        Assertions.assertEquals(func("echo ::set-output name=RESULT::test"), null)
+        Assertions.assertEquals(func("print(\"::set-output name=RESULT::test\")"), null)
+        /*多空格*/
+        Assertions.assertEquals(func(" ::set-output name=RESULT::test"), null)
+        /*windows兼容*/
+        Assertions.assertEquals(
+            func("\"::set-output name=RESULT::test\""),
+            "jobs.$jobId.steps.$stepId.outputs.RESULT=test\n"
+        )
+        /*默认*/
+        Assertions.assertEquals(
+            func("::set-output name=RESULT::test"),
+            "jobs.$jobId.steps.$stepId.outputs.RESULT=test\n"
+        )
+    }
+
+    @Test
+    fun appendGateToFileTest() {
+        fun func(str: String) = CommandLineUtils.appendGateToFile(str, File(
+            AccessController
+                .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+        ), "appendGateToFileTest")
+        /*不识别*/
+        Assertions.assertEquals(func("echo \"::set-gate-value name=pass_rate::0.9\""), null)
+        Assertions.assertEquals(func("echo '::set-gate-value name=pass_rate::0.9'"), null)
+        Assertions.assertEquals(func("echo ::set-gate-value name=pass_rate::0.9"), null)
+        Assertions.assertEquals(func("print(\"::set-gate-value name=pass_rate::0.9\")"), null)
+        /*多空格*/
+        Assertions.assertEquals(func(" ::set-gate-value name=pass_rate::0.9"), null)
+        /*windows兼容*/
+        Assertions.assertEquals(func("\"::set-gate-value name=pass_rate::0.9\""), "pass_rate=0.9\n")
+        /*默认*/
+        Assertions.assertEquals(func("::set-gate-value name=pass_rate::0.9"), "pass_rate=0.9\n")
+    }
+}

--- a/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
+++ b/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import sun.security.action.GetPropertyAction
 
-
 class CommandLineUtilsTest {
 
     @Test
@@ -69,7 +68,6 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("::set-remark 备注信息"), "BK_CI_BUILD_REMARK=备注信息\n")
         Assertions.assertEquals(func("::set-remark   备注信息"), "BK_CI_BUILD_REMARK=  备注信息\n")
     }
-
 
     @Test
     fun appendOutputToFileTest() {

--- a/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
+++ b/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
@@ -23,14 +23,17 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("\"::set-progress-rate 0.3758\""), 0.3758)
         /*默认*/
         Assertions.assertEquals(func("::set-progress-rate 0.3758"), 0.3758)
+        Assertions.assertEquals(func("::set-progress-rate    0.3758"), 0.3758)
     }
 
     @Test
     fun appendVariableToFileTest() {
-        fun func(str: String) = CommandLineUtils.appendVariableToFile(str, File(
-            AccessController
-                .doPrivileged(GetPropertyAction("java.io.tmpdir"))
-        ), "appendVariableToFileTest")
+        fun func(str: String) = CommandLineUtils.appendVariableToFile(
+            str, File(
+                AccessController
+                    .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+            ), "appendVariableToFileTest"
+        )
         /*不识别*/
         Assertions.assertEquals(func("echo \"::set-variable name=RESULT::test\""), null)
         Assertions.assertEquals(func("echo '::set-variable name=RESULT::test'"), null)
@@ -38,6 +41,7 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("print(\"::set-variable name=RESULT::test\")"), null)
         /*多空格*/
         Assertions.assertEquals(func(" ::set-variable name=RESULT::test"), null)
+        Assertions.assertEquals(func("::set-variable   name=RESULT::test"), null)
         /*windows兼容*/
         Assertions.assertEquals(func("\"::set-variable name=RESULT::test\""), "variables.RESULT=test\n")
         /*默认*/
@@ -46,10 +50,12 @@ class CommandLineUtilsTest {
 
     @Test
     fun appendRemarkToFileTest() {
-        fun func(str: String) = CommandLineUtils.appendRemarkToFile(str, File(
-            AccessController
-                .doPrivileged(GetPropertyAction("java.io.tmpdir"))
-        ), "appendRemarkToFileTest")
+        fun func(str: String) = CommandLineUtils.appendRemarkToFile(
+            str, File(
+                AccessController
+                    .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+            ), "appendRemarkToFileTest"
+        )
         /*不识别*/
         Assertions.assertEquals(func("echo \"::set-remark 备注信息\""), null)
         Assertions.assertEquals(func("echo '::set-remark 备注信息'"), null)
@@ -61,6 +67,7 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("\"::set-remark 备注信息\""), "BK_CI_BUILD_REMARK=备注信息\n")
         /*默认*/
         Assertions.assertEquals(func("::set-remark 备注信息"), "BK_CI_BUILD_REMARK=备注信息\n")
+        Assertions.assertEquals(func("::set-remark   备注信息"), "BK_CI_BUILD_REMARK=  备注信息\n")
     }
 
 
@@ -85,6 +92,7 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("print(\"::set-output name=RESULT::test\")"), null)
         /*多空格*/
         Assertions.assertEquals(func(" ::set-output name=RESULT::test"), null)
+        Assertions.assertEquals(func("::set-output    name=RESULT::test"), null)
         /*windows兼容*/
         Assertions.assertEquals(
             func("\"::set-output name=RESULT::test\""),
@@ -99,10 +107,12 @@ class CommandLineUtilsTest {
 
     @Test
     fun appendGateToFileTest() {
-        fun func(str: String) = CommandLineUtils.appendGateToFile(str, File(
-            AccessController
-                .doPrivileged(GetPropertyAction("java.io.tmpdir"))
-        ), "appendGateToFileTest")
+        fun func(str: String) = CommandLineUtils.appendGateToFile(
+            str, File(
+                AccessController
+                    .doPrivileged(GetPropertyAction("java.io.tmpdir"))
+            ), "appendGateToFileTest"
+        )
         /*不识别*/
         Assertions.assertEquals(func("echo \"::set-gate-value name=pass_rate::0.9\""), null)
         Assertions.assertEquals(func("echo '::set-gate-value name=pass_rate::0.9'"), null)
@@ -110,6 +120,7 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("print(\"::set-gate-value name=pass_rate::0.9\")"), null)
         /*多空格*/
         Assertions.assertEquals(func(" ::set-gate-value name=pass_rate::0.9"), null)
+        Assertions.assertEquals(func("::set-gate-value   name=pass_rate::0.9"), null)
         /*windows兼容*/
         Assertions.assertEquals(func("\"::set-gate-value name=pass_rate::0.9\""), "pass_rate=0.9\n")
         /*默认*/

--- a/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
+++ b/src/backend/ci/core/worker/worker-agent/src/test/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtilsTest.kt
@@ -16,13 +16,13 @@ class CommandLineUtilsTest {
         Assertions.assertEquals(func("echo '::set-progress-rate 0.3758'"), null)
         Assertions.assertEquals(func("echo ::set-progress-rate 0.3758"), null)
         Assertions.assertEquals(func("print(\"::set-progress-rate 0.3758\")"), null)
-        /*多空格*/
-        Assertions.assertEquals(func(" ::set-progress-rate 0.3758"), null)
         /*windows兼容*/
         Assertions.assertEquals(func("\"::set-progress-rate 0.3758\""), 0.3758)
         /*默认*/
         Assertions.assertEquals(func("::set-progress-rate 0.3758"), 0.3758)
+        /*兼容多空格*/
         Assertions.assertEquals(func("::set-progress-rate    0.3758"), 0.3758)
+        Assertions.assertEquals(func(" ::set-progress-rate 0.3758"), 0.3758)
     }
 
     @Test

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtils.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtils.kt
@@ -177,7 +177,7 @@ object CommandLineUtils {
         tmpLine: String
     ): Double? {
         val pattern = Pattern.compile("^[\"]?::set-progress-rate\\s*(.*)$")
-        val matcher = pattern.matcher(tmpLine)
+        val matcher = pattern.matcher(tmpLine.trim())
         if (matcher.find()) {
             val progressRate = matcher.group(1).removeSuffix("\"").toDoubleOrNull()
             if (taskId != null && progressRate != null) {

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtils.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/utils/CommandLineUtils.kt
@@ -172,22 +172,24 @@ object CommandLineUtils {
         return result.toString()
     }
 
-    private fun reportProgressRate(
+    fun reportProgressRate(
         taskId: String?,
         tmpLine: String
-    ) {
-        val pattern = Pattern.compile("::set-progress-rate\\s*(.*)")
+    ): Double? {
+        val pattern = Pattern.compile("^[\"]?::set-progress-rate\\s*(.*)$")
         val matcher = pattern.matcher(tmpLine)
         if (matcher.find()) {
-            val progressRate = matcher.group(1)
-            if (taskId != null) {
+            val progressRate = matcher.group(1).removeSuffix("\"").toDoubleOrNull()
+            if (taskId != null && progressRate != null) {
                 Heartbeat.recordTaskProgressRate(
                     taskId = taskId,
-                    progressRate = progressRate.toDouble()
+                    progressRate = progressRate
                 )
             }
             logger.info("report progress rate:$tmpLine|$taskId|$progressRate")
+            return progressRate
         }
+        return null
     }
 
     private fun appendResultToFile(
@@ -210,46 +212,48 @@ object CommandLineUtils {
         appendOutputToFile(tmpLine, workspace, resultLogFile, jobId, stepId)
     }
 
-    private fun appendVariableToFile(
+    fun appendVariableToFile(
         tmpLine: String,
         workspace: File?,
         resultLogFile: String
-    ) {
+    ): String? {
         val pattenVar = "[\"]?::set-variable\\sname=.*"
         val prefixVar = "::set-variable name="
         if (Pattern.matches(pattenVar, tmpLine)) {
             val value = tmpLine.removeSurrounding("\"").removePrefix(prefixVar)
             val keyValue = value.split("::")
             if (keyValue.size >= 2) {
-                File(workspace, resultLogFile).appendText(
-                    "variables.${keyValue[0]}=${value.removePrefix("${keyValue[0]}::")}\n"
-                )
+                val res = "variables.${keyValue[0]}=${value.removePrefix("${keyValue[0]}::")}\n"
+                File(workspace, resultLogFile).appendText(res)
+                return res
             }
         }
+        return null
     }
 
-    private fun appendRemarkToFile(
+    fun appendRemarkToFile(
         tmpLine: String,
         workspace: File?,
         resultLogFile: String
-    ) {
+    ): String? {
         val pattenVar = "[\"]?::set-remark\\s.*"
         val prefixVar = "::set-remark "
         if (Pattern.matches(pattenVar, tmpLine)) {
             val value = tmpLine.removeSurrounding("\"").removePrefix(prefixVar)
-            File(workspace, resultLogFile).appendText(
-                "BK_CI_BUILD_REMARK=$value\n"
-            )
+            val res = "BK_CI_BUILD_REMARK=$value\n"
+            File(workspace, resultLogFile).appendText(res)
+            return res
         }
+        return null
     }
 
-    private fun appendOutputToFile(
+    fun appendOutputToFile(
         tmpLine: String,
         workspace: File?,
         resultLogFile: String,
         jobId: String,
         stepId: String
-    ) {
+    ): String? {
         val pattenOutput = "[\"]?::set-output\\sname=.*"
         val prefixOutput = "::set-output name="
         if (Pattern.matches(pattenOutput, tmpLine)) {
@@ -257,29 +261,31 @@ object CommandLineUtils {
             val keyValue = value.split("::")
             val keyPrefix = "jobs.$jobId.steps.$stepId.outputs."
             if (keyValue.size >= 2) {
-                File(workspace, resultLogFile).appendText(
-                    "$keyPrefix${keyValue[0]}=${value.removePrefix("${keyValue[0]}::")}\n"
-                )
+                val res = "$keyPrefix${keyValue[0]}=${value.removePrefix("${keyValue[0]}::")}\n"
+                File(workspace, resultLogFile).appendText(res)
+                return res
             }
         }
+        return null
     }
 
-    private fun appendGateToFile(
+    fun appendGateToFile(
         tmpLine: String,
         workspace: File?,
         resultLogFile: String
-    ) {
+    ): String? {
         val pattenOutput = "[\"]?::set-gate-value\\sname=.*"
         val prefixOutput = "::set-gate-value name="
         if (Pattern.matches(pattenOutput, tmpLine)) {
             val value = tmpLine.removeSurrounding("\"").removePrefix(prefixOutput)
             val keyValue = value.split("::")
             if (keyValue.size >= 2) {
-                File(workspace, resultLogFile).appendText(
-                    "${keyValue[0]}=${value.removePrefix("${keyValue[0]}::")}\n"
-                )
+                val res = "${keyValue[0]}=${value.removePrefix("${keyValue[0]}::")}\n"
+                File(workspace, resultLogFile).appendText(res)
+                return res
             }
         }
+        return null
     }
 
     fun execute(file: File, workspace: File?, print2Logger: Boolean, prefix: String = ""): String {


### PR DESCRIPTION
#7932 fix
### 修复并增强 `reportProgressRate` 函数

### PR 描述:

此拉取请求解决了 `reportProgressRate` 函数中的一个致命问题，并引入了若干改进以增强其健壮性和功能。

#### 解决的致命问题:

原始实现中存在一个致命缺陷，即它没有处理进度率字符串无法转换为 `Double` 的情况。这会导致运行时异常和潜在的崩溃。更新后的实现通过使用 `toDoubleOrNull()` 解决了这个问题，该方法安全地处理转换并在转换失败时返回 `null`。
![image](https://github.com/user-attachments/assets/dd2ee0da-4769-442c-acc6-cf820acc7fc1)


#### 主要更改:

1. **函数可见性**:
   - **修改前**: `private fun reportProgressRate(...)`
   - **修改后**: `fun reportProgressRate(...)`
   - **原因**: 函数的可见性从 `private` 改为 `public`，以允许单测中使用

2. **补充单测**:
   - **修改前**: 无。
   - **修改后**: 详见文件。
   - **原因**: 针对这一块的文本识别，很有必要添加单测。

3. **正则表达式模式**:
   - **修改前**: `Pattern.compile("::set-progress-rate\\s*(.*)")`
   - **修改后**: `Pattern.compile("^[\"]?::set-progress-rate\\s*(.*)$")`
   - **原因**: 更新后的正则表达式模式确保即使进度率字符串被引号包围也能正确匹配。这防止了潜在的匹配错误和解析错误。

4. **进度率解析**:
   - **修改前**: `val progressRate = matcher.group(1)`
   - **修改后**: `val progressRate = matcher.group(1).removeSuffix("\"").toDoubleOrNull()`
   - **原因**: 新实现安全地将进度率转换为 `Double?`，处理转换可能失败的情况，并返回 `null` 而不是抛出异常。