### PR TITLE
feat: 优化流水线导出结构顺序 #10728

### DIFF
--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/JsonUtil.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/JsonUtil.kt
@@ -32,9 +32,11 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.Module
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.ser.FilterProvider
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider
@@ -119,20 +121,37 @@ object JsonUtil {
 
     private val objectMapper = objectMapper()
 
+    private val jsonMapper = jsonMapper()
+
     private fun objectMapper(): ObjectMapper {
         return ObjectMapper().apply {
-            registerModule(javaTimeModule())
-            registerModule(KotlinModule())
-            enable(SerializationFeature.INDENT_OUTPUT)
-            enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
-            enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
-            setSerializationInclusion(JsonInclude.Include.NON_NULL)
-            disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-            jsonModules.forEach { jsonModule ->
-                registerModule(jsonModule)
-            }
+            objectMapperInit()
         }
+    }
+
+    private fun ObjectMapper.objectMapperInit() {
+        registerModule(javaTimeModule())
+        registerModule(KotlinModule())
+        enable(SerializationFeature.INDENT_OUTPUT)
+        enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+        enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
+        setSerializationInclusion(JsonInclude.Include.NON_NULL)
+        disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+        jsonModules.forEach { jsonModule ->
+            registerModule(jsonModule)
+        }
+    }
+
+    private fun jsonMapper(): JsonMapper {
+        return JsonMapper.builder()
+            /* 使得POJO反序列化有序，对性能会有略微影响
+            *  https://github.com/FasterXML/jackson-databind/issues/3900
+            * */
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .disable(MapperFeature.SORT_CREATOR_PROPERTIES_FIRST).build().apply {
+                objectMapperInit()
+            }
     }
 
     private val skipEmptyObjectMapper = ObjectMapper().apply {
@@ -178,6 +197,7 @@ object JsonUtil {
         }
         subModules.forEach { subModule ->
             objectMapper.registerModule(subModule)
+            jsonMapper.registerModule(subModule)
             skipEmptyObjectMapper.registerModule(subModule)
             unformattedObjectMapper.registerModule(subModule)
         }
@@ -191,6 +211,13 @@ object JsonUtil {
             return bean.toString()
         }
         return getObjectMapper(formatted).writeValueAsString(bean)!!
+    }
+
+    fun toSortJson(bean: Any): String {
+        if (ReflectUtil.isNativeType(bean) || bean is String) {
+            return bean.toString()
+        }
+        return jsonMapper.writeValueAsString(bean)!!
     }
 
     /**

--- a/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/JsonUtil.kt
+++ b/src/backend/ci/core/common/common-api/src/main/kotlin/com/tencent/devops/common/api/util/JsonUtil.kt
@@ -149,6 +149,7 @@ object JsonUtil {
             *  https://github.com/FasterXML/jackson-databind/issues/3900
             * */
             .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
             .disable(MapperFeature.SORT_CREATOR_PROPERTIES_FIRST).build().apply {
                 objectMapperInit()
             }

--- a/src/backend/ci/core/common/common-pipeline/src/test/kotlin/com/tencent/devops/common/pipeline/pojo/element/ElementTest.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/test/kotlin/com/tencent/devops/common/pipeline/pojo/element/ElementTest.kt
@@ -28,8 +28,10 @@
 package com.tencent.devops.common.pipeline.pojo.element
 
 import com.tencent.devops.common.api.util.JsonUtil
+import com.tencent.devops.common.pipeline.enums.BuildScriptType
 import com.tencent.devops.common.pipeline.enums.BuildStatus
 import com.tencent.devops.common.pipeline.enums.StartType
+import com.tencent.devops.common.pipeline.pojo.element.agent.WindowsScriptElement
 import com.tencent.devops.common.pipeline.pojo.element.market.MarketBuildAtomElement
 import com.tencent.devops.common.pipeline.pojo.element.market.MarketBuildLessAtomElement
 import com.tencent.devops.common.pipeline.pojo.element.trigger.CodeGitWebHookTriggerElement
@@ -45,6 +47,21 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ElementTest {
+
+    @Test
+    fun testElementJsonOrder() {
+        val jsonFile = ElementTest::class.java.classLoader.getResource("windowsElement.json")
+        val expected = jsonFile!!.readText().trim('\n')
+        val wel = WindowsScriptElement(
+            id = "e-326ce1c320204980a3d2a0f241bccd63",
+            name = "batch script",
+            script = "unity build",
+            scriptType = BuildScriptType.BAT
+        )
+        wel.additionalOptions = elementAdditionalOptions()
+        val actual = JsonUtil.toSortJson(wel)
+        assertEquals(expected, actual)
+    }
 
     @Test
     fun unknownSubType() {

--- a/src/backend/ci/core/common/common-pipeline/src/test/resources/windowsElement.json
+++ b/src/backend/ci/core/common/common-pipeline/src/test/resources/windowsElement.json
@@ -1,0 +1,25 @@
+{
+  "@type" : "windowsScript",
+  "additionalOptions" : {
+    "continueWhenFailed" : false,
+    "enable" : true,
+    "enableCustomEnv" : true,
+    "manualRetry" : true,
+    "pauseBeforeExec" : false,
+    "retryCount" : 0,
+    "retryWhenFailed" : false,
+    "runCondition" : "PRE_TASK_SUCCESS",
+    "subscriptionPauseUser" : "",
+    "timeout" : 100
+  },
+  "atomCode" : "windowsScript",
+  "classType" : "windowsScript",
+  "elementEnable" : true,
+  "executeCount" : 1,
+  "id" : "e-326ce1c320204980a3d2a0f241bccd63",
+  "name" : "batch script",
+  "script" : "unity build",
+  "scriptType" : "BAT",
+  "taskAtom" : "",
+  "version" : "1.*"
+}

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineInfoFacadeService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/PipelineInfoFacadeService.kt
@@ -98,6 +98,12 @@ import com.tencent.devops.process.template.service.TemplateService
 import com.tencent.devops.process.yaml.PipelineYamlFacadeService
 import com.tencent.devops.process.yaml.transfer.aspect.IPipelineTransferAspect
 import com.tencent.devops.store.api.template.ServiceTemplateResource
+import java.net.URLEncoder
+import java.util.LinkedList
+import java.util.concurrent.TimeUnit
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.core.StreamingOutput
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
@@ -105,12 +111,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.stereotype.Service
-import java.net.URLEncoder
-import java.util.LinkedList
-import java.util.concurrent.TimeUnit
-import javax.ws.rs.core.MediaType
-import javax.ws.rs.core.Response
-import javax.ws.rs.core.StreamingOutput
 
 @Suppress("ALL")
 @Service
@@ -206,7 +206,7 @@ class PipelineInfoFacadeService @Autowired constructor(
             exportStringToFile(targetVersion.yaml ?: "", "${settingInfo.pipelineName}$suffix")
         } else {
             val suffix = PipelineStorageType.MODEL.fileSuffix
-            exportStringToFile(JsonUtil.toJson(modelAndSetting), "${settingInfo.pipelineName}$suffix")
+            exportStringToFile(JsonUtil.toSortJson(modelAndSetting), "${settingInfo.pipelineName}$suffix")
         }
     }
 


### PR DESCRIPTION
#10728

#### 变更内容
本次PR对`jsonMapper`方法进行了优化，主要包括以下几点：

1. **启用属性按字母顺序排序**：通过启用`MapperFeature.SORT_PROPERTIES_ALPHABETICALLY`，确保POJO在反序列化时属性按字母顺序排序。这有助于在某些情况下提高一致性和可预测性，但会对性能产生略微影响。
2. **禁用创建者属性优先排序**：通过禁用`MapperFeature.SORT_CREATOR_PROPERTIES_FIRST`，确保创建者属性不会优先排序。这可以避免在某些情况下的意外行为。
