### PR TITLE
feat：流水线版本管理机制 #8161 模板常量与流水线常量互转

### DIFF
--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/template/TemplateFacadeService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/template/TemplateFacadeService.kt
@@ -369,7 +369,7 @@ class TemplateFacadeService @Autowired constructor(
             statusCode = Response.Status.NOT_FOUND.statusCode,
             errorCode = ProcessMessageCode.ERROR_PIPELINE_MODEL_NOT_EXISTS
         )
-        val templateModel: Model = PipelineUtils.fixedTemplateParam(objectMapper.readValue(template))
+        val templateModel: Model = objectMapper.readValue(template)
         checkTemplateAtomsForExplicitVersion(templateModel, userId)
         val templateId = UUIDUtil.generate()
         dslContext.transaction { configuration ->
@@ -382,7 +382,7 @@ class TemplateFacadeService @Autowired constructor(
                 templateName = saveAsTemplateReq.templateName,
                 versionName = INIT_TEMPLATE_NAME,
                 userId = userId,
-                template = JsonUtil.toJson(templateModel, formatted = false),
+                template = template,
                 storeFlag = false,
                 version = client.get(ServiceAllocIdResource::class).generateSegmentId(TEMPLATE_BIZ_TAG_NAME).data,
                 desc = null


### PR DESCRIPTION
 #8161 
起初设想是将模板常量转换成流水线常量,流水线另存为模板时,将流水线常量转换成模板常量,但是这么实现后,会导致原有通过openapi启动可以修改模板常量,改成常量后修改失败。
所以将模板常量转换成流水线的只读变量，流水线常量另存为模板时，因为常量字段中的constant还保留的,实例化时还是可以转换成流水线常量