### PR TITLE
feat：流水线变量语法支持两种风格 #10576

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/EnvReplacementParser.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/EnvReplacementParser.kt
@@ -80,7 +80,7 @@ object EnvReplacementParser {
 
     /**
      * 根据环境变量map进行object处理并保持原类型
-     * 根据方言的配置判断是否能够使用${}或者变量值是否存在
+     * 根据方言的配置判断是否能够使用${}
      */
     fun parse(
         value: Any?,
@@ -92,7 +92,6 @@ object EnvReplacementParser {
     ): String {
         val options = ExprReplacementOptions(
             contextMap = contextMap,
-            contextNotNull = !dialect.supportMissingVar(),
             contextPair = contextPair,
             functions = functions,
             output = output

--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ClassicPipelineDialect.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ClassicPipelineDialect.kt
@@ -35,11 +35,7 @@ class ClassicPipelineDialect : IPipelineDialect {
 
     override fun supportUseExpression() = false
 
-    override fun supportUseSingleCurlyBracesVar() = true
-
     override fun supportLongVarValue() = true
 
     override fun supportChineseVarName() = true
-
-    override fun supportMissingVar() = true
 }

--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ConstrainedPipelineDialect.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ConstrainedPipelineDialect.kt
@@ -35,11 +35,7 @@ class ConstrainedPipelineDialect : IPipelineDialect {
 
     override fun supportUseExpression() = true
 
-    override fun supportUseSingleCurlyBracesVar() = false
-
     override fun supportLongVarValue() = false
 
     override fun supportChineseVarName() = false
-
-    override fun supportMissingVar() = false
 }

--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/IPipelineDialect.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/IPipelineDialect.kt
@@ -35,14 +35,10 @@ interface IPipelineDialect {
     fun getPipelineDialectType(): String
 
     /**
-     * 支持插件变量使用表达式
+     * 1. 仅支持双花括号，避免出现 bash 脚本变量在执行前被系统赋值的问题
+     * 2. 流程控制选项、插件入参、Job设置等流水线配置中均可使用函数
      */
     fun supportUseExpression(): Boolean
-    /**
-     * 是否支持${}变量引用
-     *
-     */
-    fun supportUseSingleCurlyBracesVar(): Boolean
 
     /**
      * 是否支持长变量
@@ -53,9 +49,4 @@ interface IPipelineDialect {
      * 是否支持中文变量名
      */
     fun supportChineseVarName(): Boolean
-
-    /**
-     * 是否支持变量不存在
-     */
-    fun supportMissingVar(): Boolean
 }

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/market/MarketAtomTask.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/market/MarketAtomTask.kt
@@ -45,7 +45,6 @@ import com.tencent.devops.common.api.constant.VALUE
 import com.tencent.devops.common.api.enums.OSType
 import com.tencent.devops.common.api.exception.RemoteServiceException
 import com.tencent.devops.common.api.exception.TaskExecuteException
-import com.tencent.devops.common.api.exception.VariableNotFoundException
 import com.tencent.devops.common.api.factory.BkDiskLruFileCacheFactory
 import com.tencent.devops.common.api.pojo.ErrorCode
 import com.tencent.devops.common.api.pojo.ErrorType
@@ -528,15 +527,6 @@ open class MarketAtomTask : ITask() {
                     ).parseCredentialValue(null, acrossInfo?.targetProjectId)
                 }
             }
-        } catch (exception: VariableNotFoundException) {
-            val errMessage = "Variable ${exception.variableKey} not found"
-            LoggerService.addErrorLine(errMessage)
-            throw TaskExecuteException(
-                errorMsg = "[Finish task] status: false, errorType: ${ErrorType.USER.num}, " +
-                        "errorCode: ${ErrorCode.USER_INPUT_INVAILD}, message: $errMessage",
-                errorType = ErrorType.USER,
-                errorCode = ErrorCode.USER_INPUT_INVAILD
-            )
         } catch (e: Throwable) {
             logger.error("plugin input illegal! ", e)
             LoggerService.addErrorLine("plugin input illegal! ${e.message}")

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/script/ScriptTask.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/script/ScriptTask.kt
@@ -29,7 +29,6 @@ package com.tencent.devops.worker.common.task.script
 
 import com.tencent.bkrepo.repository.pojo.token.TokenType
 import com.tencent.devops.common.api.exception.TaskExecuteException
-import com.tencent.devops.common.api.exception.VariableNotFoundException
 import com.tencent.devops.common.api.pojo.ErrorCode
 import com.tencent.devops.common.api.pojo.ErrorCode.USER_SCRIPT_TASK_FAIL
 import com.tencent.devops.common.api.pojo.ErrorType
@@ -120,15 +119,6 @@ open class ScriptTask : ITask() {
                 errorMessage = "Fail to run the plugin",
                 charsetType = charsetType,
                 taskId = buildTask.taskId
-            )
-        } catch (exception: VariableNotFoundException) {
-            val errMessage = "Variable ${exception.variableKey} not found"
-            LoggerService.addErrorLine(errMessage)
-            throw TaskExecuteException(
-                errorMsg = "[Finish task] status: false, errorType: ${ErrorType.USER.num}, " +
-                        "errorCode: ${ErrorCode.USER_INPUT_INVAILD}, message: $errMessage",
-                errorType = ErrorType.USER,
-                errorCode = ErrorCode.USER_INPUT_INVAILD
             )
         } catch (ignore: Throwable) {
             logger.warn("Fail to run the script task", ignore)


### PR DESCRIPTION
#10576 
如果同一条流水线监听push和mr，然后在bash插件中根据事件类型读取不同事件的变量，这个时候流水线执行时会报错,导致变量不存在也无法支持