### PR TITLE
feat：流水线变量语法支持两种风格 #10576 回退变量超长报错

### DIFF
--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ClassicPipelineDialect.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ClassicPipelineDialect.kt
@@ -35,7 +35,5 @@ class ClassicPipelineDialect : IPipelineDialect {
 
     override fun supportUseExpression() = false
 
-    override fun supportLongVarValue() = true
-
     override fun supportChineseVarName() = true
 }

--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ConstrainedPipelineDialect.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/ConstrainedPipelineDialect.kt
@@ -35,7 +35,5 @@ class ConstrainedPipelineDialect : IPipelineDialect {
 
     override fun supportUseExpression() = true
 
-    override fun supportLongVarValue() = false
-
     override fun supportChineseVarName() = false
 }

--- a/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/IPipelineDialect.kt
+++ b/src/backend/ci/core/common/common-pipeline/src/main/kotlin/com/tencent/devops/common/pipeline/dialect/IPipelineDialect.kt
@@ -41,11 +41,6 @@ interface IPipelineDialect {
     fun supportUseExpression(): Boolean
 
     /**
-     * 是否支持长变量
-     */
-    fun supportLongVarValue(): Boolean
-
-    /**
      * 是否支持中文变量名
      */
     fun supportChineseVarName(): Boolean

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/service/pipeline/PipelineBuildService.kt
@@ -36,7 +36,6 @@ import com.tencent.devops.common.audit.ActionAuditContent
 import com.tencent.devops.common.auth.api.ActionId
 import com.tencent.devops.common.auth.api.ResourceTypeId
 import com.tencent.devops.common.pipeline.Model
-import com.tencent.devops.common.pipeline.dialect.IPipelineDialect
 import com.tencent.devops.common.pipeline.dialect.PipelineDialectUtil
 import com.tencent.devops.common.pipeline.enums.BuildFormPropertyType
 import com.tencent.devops.common.pipeline.enums.ChannelCode
@@ -85,7 +84,6 @@ import com.tencent.devops.process.utils.PIPELINE_START_USER_ID
 import com.tencent.devops.process.utils.PIPELINE_START_USER_NAME
 import com.tencent.devops.process.utils.PIPELINE_START_WEBHOOK_USER_ID
 import com.tencent.devops.process.utils.PIPELINE_UPDATE_USER
-import com.tencent.devops.process.utils.PIPELINE_VARIABLES_STRING_LENGTH_MAX
 import com.tencent.devops.process.utils.PIPELINE_VERSION
 import com.tencent.devops.process.utils.PROJECT_NAME
 import com.tencent.devops.process.utils.PROJECT_NAME_CHINESE
@@ -249,11 +247,6 @@ class PipelineBuildService(
                 debug = debug ?: false,
                 versionName = versionName,
                 yamlVersion = yamlVersion
-            )
-            // 校验流水线启动变量长度
-            checkBuildParameterLength(
-                pipelineDialect = pipelineDialectType.dialect,
-                buildParameters = context.buildParameters
             )
 
             val interceptResult = pipelineInterceptorChain.filter(
@@ -429,20 +422,5 @@ class PipelineBuildService(
                 BuildParameters(key = TraceTag.TRACE_HEADER_DEVOPS_BIZID, value = bizId)
         }
 //        return originStartParams
-    }
-
-    private fun checkBuildParameterLength(
-        pipelineDialect: IPipelineDialect,
-        buildParameters: List<BuildParameters>
-    ) {
-        val longVarNames = buildParameters.filter {
-            it.value.toString().length >= PIPELINE_VARIABLES_STRING_LENGTH_MAX
-        }.map { it.key }
-        if (longVarNames.isNotEmpty() && !pipelineDialect.supportLongVarValue()) {
-            throw ErrorCodeException(
-                errorCode = ProcessMessageCode.ERROR_PIPELINE_VARIABLES_OUT_OF_LENGTH,
-                params = arrayOf(longVarNames.toString())
-            )
-        }
     }
 }

--- a/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/ITask.kt
+++ b/src/backend/ci/core/worker/worker-common/src/main/kotlin/com/tencent/devops/worker/common/task/ITask.kt
@@ -36,7 +36,6 @@ import com.tencent.devops.common.pipeline.pojo.BuildParameters
 import com.tencent.devops.process.pojo.BuildTask
 import com.tencent.devops.process.pojo.BuildVariables
 import com.tencent.devops.process.utils.PIPELINE_DIALECT
-import com.tencent.devops.process.utils.PIPELINE_VARIABLES_STRING_LENGTH_MAX
 import com.tencent.devops.worker.common.env.BuildEnv
 import com.tencent.devops.worker.common.env.BuildType
 import com.tencent.devops.worker.common.logger.LoggerService
@@ -105,18 +104,12 @@ abstract class ITask {
 
     protected fun addEnv(env: Map<String, String>) {
         var errReadOnlyFlag = false
-        var errLongValueFlag = false
-        val errLongValueVars = mutableSetOf<String>()
         var errChineseVarName = false
         val errChineseVars = mutableSetOf<String>()
-        env.forEach { (key, value) ->
+        env.keys.forEach { key ->
             if (this::constVar.isInitialized && key in constVar) {
                 LoggerService.addErrorLine("Variable $key is read-only and cannot be modified.")
                 errReadOnlyFlag = true
-            }
-            if (value.length >= PIPELINE_VARIABLES_STRING_LENGTH_MAX) {
-                errLongValueVars.add(key)
-                errLongValueFlag = true
             }
             if (!Pattern.matches(ENGLISH_NAME_PATTERN, key)) {
                 errChineseVars.add(key)
@@ -132,16 +125,6 @@ abstract class ITask {
             )
         }
         if (this::dialect.isInitialized) {
-            if (errLongValueFlag && !dialect.supportLongVarValue()) {
-                LoggerService.addWarnLine("Variable $errLongValueVars value exceeds 4000 length limit.")
-                throw TaskExecuteException(
-                    errorMsg = "[Finish task] status: false, errorType: ${ErrorType.USER.num}, " +
-                            "errorCode: ${ErrorCode.USER_INPUT_INVAILD}," +
-                            " message: variable value exceeds 4000 length limit.",
-                    errorType = ErrorType.USER,
-                    errorCode = ErrorCode.USER_INPUT_INVAILD
-                )
-            }
             if (errChineseVarName && !dialect.supportChineseVarName()) {
                 LoggerService.addWarnLine(
                     "Variable $errChineseVars name is illegal,Variable names can only use letters, " +


### PR DESCRIPTION
#10576 
回退变量超长报错,因为插件可能输出超长变量,导致流水线报错,但是用户配置的流水线又不能修改