### PR TITLE
bug:插件最新版本使用历史版本修复方式发布后，再用普通方式发布的分支会继承上一次的 #11301

### DIFF
--- a/src/backend/ci/core/store/api-store/src/main/kotlin/com/tencent/devops/store/pojo/atom/MarketAtomUpdateRequest.kt
+++ b/src/backend/ci/core/store/api-store/src/main/kotlin/com/tencent/devops/store/pojo/atom/MarketAtomUpdateRequest.kt
@@ -73,7 +73,7 @@ data class MarketAtomUpdateRequest(
     @get:Schema(title = "插件字段校验确认标识", required = false)
     val fieldCheckConfirmFlag: Boolean? = false,
     @get:Schema(title = "分支", required = false)
-    val branch: String? = null,
+    var branch: String? = null,
     @get:Schema(title = "是否属于分支测试版本", required = false)
     var isBranchTestVersion: Boolean = false
 )

--- a/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/atom/service/impl/AtomReleaseServiceImpl.kt
+++ b/src/backend/ci/core/store/biz-store/src/main/kotlin/com/tencent/devops/store/atom/service/impl/AtomReleaseServiceImpl.kt
@@ -351,6 +351,7 @@ abstract class AtomReleaseServiceImpl @Autowired constructor() : AtomReleaseServ
         val branch = if (marketAtomUpdateRequest.branch.isNullOrBlank() ||
             releaseType != ReleaseTypeEnum.HIS_VERSION_UPGRADE
         ) {
+            marketAtomUpdateRequest.branch = MASTER
             MASTER
         } else {
             marketAtomUpdateRequest.branch


### PR DESCRIPTION
bug:插件最新版本使用历史版本修复方式发布后，再用普通方式发布的分支会继承上一次的 #11301