### PR TITLE
bugfix: 遇到停止/取消等行为直接结束未启动的stage，不进行依赖判断 #11313

### DIFF
--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/stage/impl/CheckConditionalSkipStageCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/stage/impl/CheckConditionalSkipStageCmd.kt
@@ -59,6 +59,14 @@ class CheckConditionalSkipStageCmd constructor(
 
     override fun execute(commandContext: StageContext) {
         val stage = commandContext.stage
+        val event = commandContext.event
+        // 遇到停止/取消等行为直接结束，因为本Stage还未进入
+        if (event.actionType.isEnd() && commandContext.buildStatus.isReadyToRun()) {
+            commandContext.buildStatus = BuildStatus.CANCELED
+            commandContext.cmdFlowState = CmdFlowState.FINALLY
+            LOG.info("ENGINE|${event.buildId}|${event.source}|STAGE_CANCEL|${event.stageId}")
+            return
+        }
         // 仅在初次进入Stage时进行跳过和依赖判断
         try {
             if (checkIfSkip(commandContext)) {

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/stage/impl/CheckPauseReviewStageCmd.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/command/stage/impl/CheckPauseReviewStageCmd.kt
@@ -71,9 +71,7 @@ class CheckPauseReviewStageCmd(
         val event = commandContext.event
 
         // 处于等待中，遇到停止/取消等行为直接结束，因为本Stage还未进入
-        if (event.actionType.isEnd() &&
-            (commandContext.buildStatus.isPause() || commandContext.buildStatus.isReadyToRun())
-        ) {
+        if (event.actionType.isEnd() && commandContext.buildStatus.isPause()) {
             commandContext.buildStatus = BuildStatus.CANCELED
             commandContext.cmdFlowState = CmdFlowState.FINALLY
             LOG.info("ENGINE|${event.buildId}|${event.source}|STAGE_CANCEL|${event.stageId}")


### PR DESCRIPTION
#11313