### PR TITLE
bug: 代码框架升级导致Jersey 的 getAnnotation方法获取不到方法上的注解 #12237

### DIFF
--- a/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/filter/RequestProjectPermissionFilter.kt
+++ b/src/backend/ci/core/common/common-web/src/main/kotlin/com/tencent/devops/common/web/filter/RequestProjectPermissionFilter.kt
@@ -50,6 +50,7 @@ import jakarta.ws.rs.container.ResourceInfo
 import jakarta.ws.rs.core.Context
 import jakarta.ws.rs.core.UriInfo
 import jakarta.ws.rs.ext.Provider
+import org.springframework.core.annotation.AnnotationUtils
 
 @Provider
 @RequestFilter
@@ -76,8 +77,8 @@ class RequestProjectPermissionFilter(
         }
         // 判断接口是否标注了免权限校验的注解
         val method = resourceInfo!!.resourceMethod
-        val bkApiHandleType = method.getAnnotation(BkApiPermission::class.java)?.types?.toList()
-        val noAuthCheckFlag = bkApiHandleType?.contains(BkApiHandleType.API_NO_AUTH_CHECK) ?: false
+        val bkApiHandleTypes = AnnotationUtils.findAnnotation(method, BkApiPermission::class.java)?.types?.toList()
+        val noAuthCheckFlag = bkApiHandleTypes?.contains(BkApiHandleType.API_NO_AUTH_CHECK) ?: false
         // 如果接口免权限校验、接口类型是get请求或者接口是build接口等情况无需做权限校验（未结束的构建需要调build接口才能完成）
         val url = requestContext.uriInfo.requestUri.path
         val channel = I18nUtil.getRequestChannel()

--- a/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/cron/process/PipelineBuildHistoryDataClearJob.kt
+++ b/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/cron/process/PipelineBuildHistoryDataClearJob.kt
@@ -354,16 +354,16 @@ class PipelineBuildHistoryDataClearJob @Autowired constructor(
         maxStartTime: LocalDateTime? = null,
         archiveFlag: Boolean? = null
     ) {
-        val totalBuildCount = processMiscService.getTotalBuildCount(
+        val maxPipelineBuildNum = processMiscService.getMaxPipelineBuildNum(
             projectId = projectId,
             pipelineId = pipelineId,
             maxBuildNum = maxBuildNum,
             maxStartTime = maxStartTime,
             archiveFlag = archiveFlag
         )
-        logger.info("pipelineBuildHistoryDataClear|$projectId|$pipelineId|totalBuildCount=$totalBuildCount")
+        logger.info("pipelineBuildHistoryDataClear|$projectId|$pipelineId|maxPipelineBuildNum=$maxPipelineBuildNum")
         var totalHandleNum = processMiscService.getMinPipelineBuildNum(projectId, pipelineId, archiveFlag).toInt()
-        while (totalHandleNum < totalBuildCount) {
+        while (totalHandleNum <= maxPipelineBuildNum) {
             val cleanBuilds = mutableListOf<String>()
             val pipelineHistoryBuildIdList = processMiscService.getHistoryBuildIdList(
                 projectId = projectId,

--- a/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/dao/process/ProcessDao.kt
+++ b/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/dao/process/ProcessDao.kt
@@ -177,7 +177,7 @@ class ProcessDao {
         }
     }
 
-    fun getTotalBuildCount(
+    fun getMaxPipelineBuildNum(
         dslContext: DSLContext,
         projectId: String,
         pipelineId: String,

--- a/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/service/process/ProcessMiscService.kt
+++ b/src/backend/ci/core/misc/biz-misc/src/main/kotlin/com/tencent/devops/misc/service/process/ProcessMiscService.kt
@@ -150,7 +150,7 @@ class ProcessMiscService @Autowired constructor(
         return processDao.getMinPipelineBuildNum(generateQueryDslContext(archiveFlag), projectId, pipelineId)
     }
 
-    fun getTotalBuildCount(
+    fun getMaxPipelineBuildNum(
         projectId: String,
         pipelineId: String,
         maxBuildNum: Int? = null,
@@ -158,7 +158,7 @@ class ProcessMiscService @Autowired constructor(
         geTimeFlag: Boolean? = null,
         archiveFlag: Boolean? = null
     ): Long {
-        return processDao.getTotalBuildCount(
+        return processDao.getMaxPipelineBuildNum(
             dslContext = generateQueryDslContext(archiveFlag),
             projectId = projectId,
             pipelineId = pipelineId,


### PR DESCRIPTION
bug: 代码框架升级导致Jersey 的 getAnnotation方法获取不到方法上的注解 #12237