### PR TITLE
fix: optimize artifact download preparation text

### DIFF
--- a/src/frontend/locale/flow/zh-CN.json
+++ b/src/frontend/locale/flow/zh-CN.json
@@ -886,7 +886,7 @@
       "downloadDisabledTips": "目录下的文件大小超过 10 G，请到制品库分批下载",
       "noDownloadPermTips": "你没有该创作流的下载构件权限，无法下载",
       "needSignTips": "{0} 为内部测试版本，正在准备下载，请稍等",
-      "apkSignDurationTips": "仅首次下载需等待，准备时长和包大小有关，500MB的包大概需要1分钟",
+      "apkSignDurationTips": "仅首次下载需等待，准备时长和包大小有关，500MB 的包大概需要 1分钟",
       "downloadLater": "稍后再下载",
       "serachCustomRepo": "搜索自定义仓库",
       "copyArtifactTo": "将制品 <b>{0}</b> 复制到",

--- a/src/frontend/locale/pipeline/zh-CN.json
+++ b/src/frontend/locale/pipeline/zh-CN.json
@@ -1937,7 +1937,7 @@
   "scanQRCodeView": "使用蓝盾 APP<br/>扫码查看构件列表",
   "runs": "次",
   "needSignTips": "{0} 为内部测试版本，正在准备下载，请稍等",
-  "apkSignDurationTips": "仅首次下载需等待，准备时长和包大小有关，500MB的包大概需要1分钟",
+  "apkSignDurationTips": "仅首次下载需等待，准备时长和包大小有关，500MB 的包大概需要 1分钟",
   "apkSignSuccess": "{0} 已经准备完成，开始下载",
   "downloadLater": "稍后再下载",
   "copyAsTemplateInstance": "复制为模板实例",


### PR DESCRIPTION
## Summary

- Normalize Chinese spacing in artifact download preparation tips.
- Update both pipeline and flow locale strings on the GitHub baseline.

## Issue

Closes #13328

## Validation

- Parsed updated locale JSON files with Node.js.

