### PR TITLE
pref：metrics Job 每日度量写入支持幂等更新 #13366

### DIFF
--- a/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/DispatchJobMetricsDao.kt
+++ b/src/backend/ci/core/metrics/biz-metrics/src/main/kotlin/com/tencent/devops/metrics/dao/DispatchJobMetricsDao.kt
@@ -55,7 +55,9 @@ class DispatchJobMetricsDao {
                 .set(CHANNEL_CODE, jobMetricsData.channelCode)
                 .set(MAX_JOB_CONCURRENCY, jobMetricsData.maxJobConcurrency)
                 .set(SUM_JOB_COST, jobMetricsData.sumJobCost)
-                .set(CHANNEL_CODE, jobMetricsData.channelCode)
+                .onDuplicateKeyUpdate()
+                .set(MAX_JOB_CONCURRENCY, jobMetricsData.maxJobConcurrency)
+                .set(SUM_JOB_COST, jobMetricsData.sumJobCost)
                 .execute()
         }
     }


### PR DESCRIPTION
## Summary

- 将 Job 每日度量写入调整为 `ON DUPLICATE KEY UPDATE`
- 重复上报时更新最大并发数和累计 Job 耗时，避免唯一键冲突导致接口返回 500
- 移除重复设置 `CHANNEL_CODE` 的无效代码

## Test plan

- [x] `./gradlew :core:metrics:biz-metrics:compileKotlin`
- [x] 确认仅修改 `DispatchJobMetricsDao.saveDispatchJobMetrics`

Closes #13366