### PR TITLE
feat: support hiding actions column issue #13376

### DIFF
--- a/src/frontend/devops-pipeline/src/components/BuildHistoryTable/index.vue
+++ b/src/frontend/devops-pipeline/src/components/BuildHistoryTable/index.vue
@@ -410,26 +410,22 @@
                         </div>
                         <span v-else>--</span>
                     </template>
+                    <template
+                        v-else-if="col.id === 'operate'"
+                        v-slot="props"
+                    >
+                        <bk-button
+                            v-if="retryable(props.row)"
+                            text
+                            theme="primary"
+                            size="small"
+                            @click.stop="retry(props.row.id)"
+                        >
+                            {{ $t('history.reBuild') }}
+                        </bk-button>
+                    </template>
                 </bk-table-column>
                 <template v-if="!archiveFlag">
-                    <bk-table-column
-                        v-if="!isDebug"
-                        :label="$t('operate')"
-                        fixed="right"
-                        width="80"
-                    >
-                        <template v-slot="props">
-                            <bk-button
-                                v-if="retryable(props.row)"
-                                text
-                                theme="primary"
-                                size="small"
-                                @click.stop="retry(props.row.id)"
-                            >
-                                {{ $t(isDebug ? 'reDebug' : 'history.reBuild') }}
-                            </bk-button>
-                        </template>
-                    </bk-table-column>
                     <bk-table-column
                         type="setting"
                         :tippy-options="{ zIndex: 3000 }"
@@ -648,6 +644,19 @@
     } from '@/utils/permission'
 
     const LS_COLUMN_KEY = 'shownColumnsKeys'
+    const LS_COLUMN_VERSION_KEY = 'shownColumnsKeysVersion'
+    const COLUMN_CONFIG_VERSION = '2'
+    function getInitSortedColumns () {
+        const lsColumns = localStorage.getItem(LS_COLUMN_KEY)
+        const lsColumnVersion = localStorage.getItem(LS_COLUMN_VERSION_KEY)
+        const columns = lsColumns ? JSON.parse(lsColumns) : BUILD_HISTORY_TABLE_DEFAULT_COLUMNS
+
+        if (lsColumns && lsColumnVersion !== COLUMN_CONFIG_VERSION && !columns.includes('operate')) {
+            return [...columns, 'operate']
+        }
+
+        return columns
+    }
     export default {
         name: 'build-history-table',
         components: {
@@ -668,8 +677,7 @@
             isDebug: Boolean
         },
         data () {
-            const lsColumns = localStorage.getItem(LS_COLUMN_KEY)
-            const initSortedColumns = lsColumns ? JSON.parse(lsColumns) : BUILD_HISTORY_TABLE_DEFAULT_COLUMNS
+            const initSortedColumns = getInitSortedColumns()
             return {
                 RESOURCE_ACTION,
                 RESOURCE_TYPE,
@@ -705,7 +713,9 @@
                 return BUILD_HISTORY_TABLE_COLUMNS_MAP
             },
             tableColumnFields () {
-                return this.tableColumnKeys.map(key => this.allTableColumnMap[key])
+                return this.tableColumnKeys
+                    .map(key => this.allTableColumnMap[key])
+                    .filter(col => col && !(col.id === 'operate' && (this.archiveFlag || this.isDebug)))
             },
             projectId () {
                 return this.$route.params.projectId
@@ -944,10 +954,12 @@
                 this.tableColumnKeys = columns
                 this.$refs.tableSetting.$parent.instance?.hide()
                 localStorage.setItem(LS_COLUMN_KEY, JSON.stringify(columns))
+                localStorage.setItem(LS_COLUMN_VERSION_KEY, COLUMN_CONFIG_VERSION)
             },
             handleColumnReset () {
                 this.tableColumnKeys = [...BUILD_HISTORY_TABLE_DEFAULT_COLUMNS]
                 localStorage.setItem(LS_COLUMN_KEY, JSON.stringify(BUILD_HISTORY_TABLE_DEFAULT_COLUMNS))
+                localStorage.setItem(LS_COLUMN_VERSION_KEY, COLUMN_CONFIG_VERSION)
                 this.$refs.tableSetting.$parent.instance?.hide()
             },
             async requestHistory () {

--- a/src/frontend/devops-pipeline/src/utils/pipelineConst.js
+++ b/src/frontend/devops-pipeline/src/utils/pipelineConst.js
@@ -171,7 +171,8 @@ export const BUILD_HISTORY_TABLE_DEFAULT_COLUMNS = [
     'artifactQuality',
     'pipelineVersion',
     'remark',
-    'errorCode'
+    'errorCode',
+    'operate'
 ]
 export const BUILD_HISTORY_TABLE_COLUMNS_MAP = {
     buildNum: {
@@ -295,6 +296,13 @@ export const BUILD_HISTORY_TABLE_COLUMNS_MAP = {
         width: 180,
         id: 'buildMsg',
         label: 'history.buildMsg'
+    },
+    operate: {
+        index: 18,
+        id: 'operate',
+        label: 'operate',
+        fixed: 'right',
+        width: localStorage.getItem('operateWidth') ?? 80
     }
 }
 


### PR DESCRIPTION
## Summary

- Add the build history actions column to the table column settings.
- Preserve the retry/rebuild action behavior while allowing the column to be hidden.
- Migrate existing local column preferences so the actions column remains visible by default.

## Validation

- `pnpm --filter devops-pipeline exec eslint src/components/BuildHistoryTable/index.vue src/utils/pipelineConst.js`
- Development-environment verification passed with internal develop commit `e675f349e39`.
- Test branch promotion completed with internal test commit `5ea274c8777`.

## Related Issue

Closes #13376
