### PR TITLE
fix: 插件面板初始化使用黑色背景 issue #12805

### DIFF
--- a/src/frontend/devops-pipeline/src/components/ExecDetail/detailContainer.vue
+++ b/src/frontend/devops-pipeline/src/components/ExecDetail/detailContainer.vue
@@ -5,7 +5,7 @@
         </span> -->
         <section
             v-bk-clickoutside="closeLog"
-            :class="[currentTab === 'log' ? 'black-theme over-hidden' : 'white-theme', 'log-main']"
+            :class="[currentTab && currentTab !== 'log' ? 'white-theme' : 'black-theme over-hidden', 'log-main']"
         >
             <header class="log-head">
                 <span class="log-title"><status-icon

--- a/src/frontend/devops-pipeline/src/components/ExecDetail/log/jobLog.vue
+++ b/src/frontend/devops-pipeline/src/components/ExecDetail/log/jobLog.vue
@@ -310,6 +310,8 @@
 <style lang="scss" scoped>
     .job-log {
         height: calc(100% - 59px);
+        flex: 1 1 auto;
+        min-width: 0;
         .log-tools {
             position: absolute;
             right: 20px;

--- a/src/frontend/devops-pipeline/src/components/ExecDetail/log/pluginLog.vue
+++ b/src/frontend/devops-pipeline/src/components/ExecDetail/log/pluginLog.vue
@@ -197,6 +197,7 @@
         mounted () {
             this.getLog()
             this.checkAIStatus()
+            this.refreshLogLayout()
         },
 
         beforeDestroy () {
@@ -220,6 +221,14 @@
                 this.getAIStatus().then(res => {
                     this.enableAI = res.data
                     this.aiTips = this.$t('details.aiAnalysis', [this.$pipelineDocs.AIAnalysis])
+                })
+            },
+
+            refreshLogLayout () {
+                this.$nextTick(() => {
+                    window.requestAnimationFrame(() => {
+                        window.dispatchEvent(new Event('resize'))
+                    })
                 })
             },
 

--- a/src/frontend/devops-pipeline/src/components/ExecDetail/plugin.vue
+++ b/src/frontend/devops-pipeline/src/components/ExecDetail/plugin.vue
@@ -230,16 +230,29 @@
                     orderedTabs.push(reportTab)
                 }
 
-                const visibleTabs = orderedTabs.filter(tab => tab.show)
-                if (!visibleTabs.some(tab => tab.name === this.currentTab)) {
-                    this.currentTab = visibleTabs.find(tab => tab.name === this.defaultTab)?.name
-                        ?? visibleTabs[0]?.name
-                }
                 return orderedTabs
+            },
+            visibleTabList () {
+                return this.sortedTabList.filter(tab => tab.show)
+            },
+            visibleTabKey () {
+                return this.visibleTabList.map(tab => tab.name).join('|')
             }
         },
 
         watch: {
+            isGetPluginHeadTab: {
+                immediate: true,
+                handler (visible) {
+                    if (visible) this.ensureCurrentTab()
+                }
+            },
+            visibleTabKey: {
+                immediate: true,
+                handler () {
+                    if (this.isGetPluginHeadTab) this.ensureCurrentTab()
+                }
+            },
             'currentElement.id': function () {
                 this.userSelectedTab = false
                 this.tabList = [
@@ -257,6 +270,13 @@
             selectTab (name) {
                 this.userSelectedTab = true
                 this.currentTab = name
+            },
+
+            ensureCurrentTab () {
+                if (!this.visibleTabList.some(tab => tab.name === this.currentTab)) {
+                    this.currentTab = this.visibleTabList.find(tab => tab.name === this.defaultTab)?.name
+                        ?? this.visibleTabList[0]?.name
+                }
             },
 
             toggleTab (key, show = false) {

--- a/src/frontend/devops-pipeline/src/components/StageSteps/index.vue
+++ b/src/frontend/devops-pipeline/src/components/StageSteps/index.vue
@@ -126,7 +126,6 @@
         },
         computed: {
             hasProgressLoader () {
-                debugger
                 return typeof this.progressLoader === 'function'
             },
             progressTooltipConfig () {

--- a/src/frontend/devops-repo/src/views/Package.tsx
+++ b/src/frontend/devops-repo/src/views/Package.tsx
@@ -140,7 +140,6 @@ export default defineComponent({
       activeOperation(operation, version, () => {
         switch (operation.id) {
           case OperateName.DELETE:
-            debugger;
             versionList.value = versionList.value.filter(v => v.name !== version.name);
             if (routeParams.value.version === version.name) { // 删除的是当前版本，切换到最新版本
               switchVersion(versionList.value[0]?.name);


### PR DESCRIPTION
## Summary
- 初始化阶段使用黑色背景，避免插件面板等待 Tab 状态时闪白。
- Progress Tab 按数据展示逻辑已存在于 master，本 PR 仅提交额外的黑底修复。

## Validation
- ESLint: detailContainer.vue