### PR TITLE
bug: 当流水线配置了同一时间只允许一条流水线跑（取消正在运行的构建）时，重试时可能误把最新的构建取消掉 #13450

### DIFF
--- a/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/engine/pojo/ConcurrencyGroupBuild.kt
+++ b/src/backend/ci/core/process/api-process/src/main/kotlin/com/tencent/devops/process/engine/pojo/ConcurrencyGroupBuild.kt
@@ -1,0 +1,38 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 Tencent.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.devops.process.engine.pojo
+
+/**
+ * 并发组内的构建引用。
+ * 查询时一并带出 [buildNum]，避免 cancel-in-progress 过滤时再按 buildId 回表。
+ */
+data class ConcurrencyGroupBuild(
+    val pipelineId: String,
+    val buildId: String,
+    val buildNum: Int
+)

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildDao.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/dao/PipelineBuildDao.kt
@@ -50,6 +50,7 @@ import com.tencent.devops.model.process.tables.records.TPipelineBuildHistoryReco
 import com.tencent.devops.process.constant.ProcessMessageCode
 import com.tencent.devops.process.engine.pojo.BuildInfo
 import com.tencent.devops.process.engine.pojo.BuildRetryInfo
+import com.tencent.devops.process.engine.pojo.ConcurrencyGroupBuild
 import com.tencent.devops.process.engine.pojo.builds.BuildHistoryQueryParam
 import com.tencent.devops.process.engine.pojo.builds.HistoryConditionQueryParam
 import com.tencent.devops.process.engine.pojo.builds.HistoryConditionQueryResult
@@ -316,21 +317,32 @@ class PipelineBuildDao {
         dslContext: DSLContext,
         projectId: String,
         concurrencyGroup: String,
-        statusSet: List<BuildStatus>
-    ): List<Record2<String, String>> {
+        statusSet: List<BuildStatus>,
+        excludeBuildId: String? = null
+    ): List<ConcurrencyGroupBuild> {
         val normal = with(T_PIPELINE_BUILD_HISTORY) {
-            dslContext.select(PIPELINE_ID, BUILD_ID).from(this)
+            val where = dslContext.select(PIPELINE_ID, BUILD_ID, BUILD_NUM).from(this)
                 .where(PROJECT_ID.eq(projectId))
                 .and(STATUS.`in`(statusSet.map { it.ordinal }))
-                .and(CONCURRENCY_GROUP.eq(concurrencyGroup)).orderBy(START_TIME.asc())
-                .fetch()
+                .and(CONCURRENCY_GROUP.eq(concurrencyGroup))
+            if (!excludeBuildId.isNullOrBlank()) {
+                where.and(BUILD_ID.ne(excludeBuildId))
+            }
+            where.orderBy(START_TIME.asc()).fetch().map { record ->
+                toConcurrencyGroupBuild(record.value1(), record.value2(), record.value3())
+            }
         }
         val debug = with(T_PIPELINE_BUILD_HISTORY_DEBUG) {
-            dslContext.select(PIPELINE_ID, BUILD_ID).from(this)
+            val where = dslContext.select(PIPELINE_ID, BUILD_ID, BUILD_NUM).from(this)
                 .where(PROJECT_ID.eq(projectId))
                 .and(STATUS.`in`(statusSet.map { it.ordinal }))
-                .and(CONCURRENCY_GROUP.eq(concurrencyGroup)).orderBy(START_TIME.asc())
-                .fetch()
+                .and(CONCURRENCY_GROUP.eq(concurrencyGroup))
+            if (!excludeBuildId.isNullOrBlank()) {
+                where.and(BUILD_ID.ne(excludeBuildId))
+            }
+            where.orderBy(START_TIME.asc()).fetch().map { record ->
+                toConcurrencyGroupBuild(record.value1(), record.value2(), record.value3())
+            }
         }
         return normal.plus(debug)
     }
@@ -339,26 +351,47 @@ class PipelineBuildDao {
         dslContext: DSLContext,
         projectId: String,
         pipelineId: String,
-        statusSet: List<BuildStatus>
-    ): List<Record2<String, String>> {
+        statusSet: List<BuildStatus>,
+        excludeBuildId: String? = null
+    ): List<ConcurrencyGroupBuild> {
         val normal = with(T_PIPELINE_BUILD_HISTORY) {
-            dslContext.select(PIPELINE_ID, BUILD_ID).from(this)
+            val where = dslContext.select(PIPELINE_ID, BUILD_ID, BUILD_NUM).from(this)
                 .where(PROJECT_ID.eq(projectId))
                 .and(PIPELINE_ID.eq(pipelineId))
                 .and(STATUS.`in`(statusSet.map { it.ordinal }))
-                .and(CONCURRENCY_GROUP.isNull).orderBy(START_TIME.asc())
-                .fetch()
+                .and(CONCURRENCY_GROUP.isNull)
+            if (!excludeBuildId.isNullOrBlank()) {
+                where.and(BUILD_ID.ne(excludeBuildId))
+            }
+            where.orderBy(START_TIME.asc()).fetch().map { record ->
+                toConcurrencyGroupBuild(record.value1(), record.value2(), record.value3())
+            }
         }
         val debug = with(T_PIPELINE_BUILD_HISTORY_DEBUG) {
-            dslContext.select(PIPELINE_ID, BUILD_ID).from(this)
+            val where = dslContext.select(PIPELINE_ID, BUILD_ID, BUILD_NUM).from(this)
                 .where(PROJECT_ID.eq(projectId))
                 .and(PIPELINE_ID.eq(pipelineId))
                 .and(STATUS.`in`(statusSet.map { it.ordinal }))
-                .and(CONCURRENCY_GROUP.isNull).orderBy(START_TIME.asc())
-                .fetch()
+                .and(CONCURRENCY_GROUP.isNull)
+            if (!excludeBuildId.isNullOrBlank()) {
+                where.and(BUILD_ID.ne(excludeBuildId))
+            }
+            where.orderBy(START_TIME.asc()).fetch().map { record ->
+                toConcurrencyGroupBuild(record.value1(), record.value2(), record.value3())
+            }
         }
         return normal.plus(debug)
     }
+
+    private fun toConcurrencyGroupBuild(
+        pipelineId: String,
+        buildId: String,
+        buildNum: Int?
+    ) = ConcurrencyGroupBuild(
+        pipelineId = pipelineId,
+        buildId = buildId,
+        buildNum = buildNum ?: 0
+    )
 
     /**
      * 查询BuildInfo，兼容所有运行时调用，不排除已删除的调试记录

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/interceptor/QueueInterceptor.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/interceptor/QueueInterceptor.kt
@@ -46,6 +46,8 @@ import com.tencent.devops.process.engine.pojo.event.PipelineBuildCancelEvent
 import com.tencent.devops.process.engine.service.PipelineRedisService
 import com.tencent.devops.process.engine.service.PipelineRuntimeExtService
 import com.tencent.devops.process.engine.service.PipelineRuntimeService
+import com.tencent.devops.process.engine.utils.ConcurrencyCancelContext
+import com.tencent.devops.process.engine.utils.ConcurrencyCancelGuardUtils
 import kotlin.math.max
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -105,8 +107,7 @@ class QueueInterceptor @Autowired constructor(
                 checkRunLockWithGroupType(
                     task = task,
                     latestBuildId = buildSummaryRecord.latestBuildId,
-                    latestStartUser = buildSummaryRecord.latestStartUser,
-                    runningCount = buildSummaryRecord.runningCount
+                    latestStartUser = buildSummaryRecord.latestStartUser
                 )
 
             (buildSummaryRecord.queueCount + buildSummaryRecord.runningCount) >= max(
@@ -277,8 +278,7 @@ class QueueInterceptor @Autowired constructor(
     private fun checkRunLockWithGroupType(
         task: InterceptData,
         latestBuildId: String?,
-        latestStartUser: String?,
-        runningCount: Int
+        latestStartUser: String?
     ): Response<BuildStatus> {
         val projectId = task.pipelineInfo.projectId
         val concurrencyGroup = task.concurrencyGroup ?: task.pipelineInfo.pipelineId
@@ -294,11 +294,13 @@ class QueueInterceptor @Autowired constructor(
                 )
                 // cancel-in-progress: true时， 若有相同 group 的流水线正在执行，则取消正在执行的流水线，新来的触发开始执行
                 // status 取所有没有完成的状态
-                val status = BuildStatus.values().filterNot { it.isFinish() }
+                val status = BuildStatus.entries.filterNot { it.isFinish() }
+                // #13450 重试复用当前 buildId，查询时排除自己，避免把当前构建误取消
                 val builds = pipelineRuntimeService.getBuildInfoListByConcurrencyGroup(
                     projectId = projectId,
                     concurrencyGroup = concurrencyGroup,
-                    status = status
+                    status = status,
+                    excludeBuildId = task.buildId
                 ).toMutableList()
                 // #8143 兼容旧流水线版本 TODO 待模板设置补上漏洞，后期下掉 # 8143
                 if (concurrencyGroup == task.pipelineInfo.pipelineId) {
@@ -307,15 +309,24 @@ class QueueInterceptor @Autowired constructor(
                         pipelineRuntimeService.getBuildInfoListByConcurrencyGroupNull(
                             projectId = projectId,
                             pipelineId = task.pipelineInfo.pipelineId,
-                            status = status
+                            status = status,
+                            excludeBuildId = task.buildId
                         )
                     )
                 }
-                builds.forEach { (pipelineId, buildId) ->
+                val cancelTargets = ConcurrencyCancelGuardUtils.filterTargets(
+                    candidateBuilds = builds,
+                    currentContext = ConcurrencyCancelContext.of(
+                        pipelineId = task.pipelineInfo.pipelineId,
+                        buildId = task.buildId,
+                        isRetry = task.retry == true
+                    ) { pipelineRuntimeService.getBuildInfo(projectId, task.buildId)?.buildNum }
+                )
+                cancelTargets.forEach { target ->
                     pipelineRuntimeService.concurrencyCancelBuildPipeline(
                         projectId = projectId,
-                        pipelineId = pipelineId,
-                        buildId = buildId,
+                        pipelineId = target.pipelineId,
+                        buildId = target.buildId,
                         userId = latestStartUser ?: task.pipelineInfo.creator,
                         groupName = concurrencyGroup,
                         detailUrl = detailUrl
@@ -334,13 +345,13 @@ class QueueInterceptor @Autowired constructor(
                         projectId = projectId,
                         concurrencyGroup = concurrencyGroup,
                         status = listOf(BuildStatus.RUNNING)
-                    ).count { it.first == task.pipelineInfo.pipelineId },
+                    ).count { it.pipelineId == task.pipelineInfo.pipelineId },
                     // #7681 在history表中取出当前流水线下相同并发组排队的数量。
                     queueCount = pipelineRuntimeService.getBuildInfoListByConcurrencyGroup(
                         projectId = projectId,
                         concurrencyGroup = concurrencyGroup,
                         status = listOf(BuildStatus.QUEUE)
-                    ).count { it.first == task.pipelineInfo.pipelineId },
+                    ).count { it.pipelineId == task.pipelineInfo.pipelineId },
                     groupName = concurrencyGroup
                 )
             }

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/service/PipelineRuntimeService.kt
@@ -100,6 +100,7 @@ import com.tencent.devops.process.engine.dao.PipelineResourceVersionDao
 import com.tencent.devops.process.engine.dao.PipelineTriggerReviewDao
 import com.tencent.devops.process.engine.pojo.AgentReuseMutexTree
 import com.tencent.devops.process.engine.pojo.BuildInfo
+import com.tencent.devops.process.engine.pojo.ConcurrencyGroupBuild
 import com.tencent.devops.process.engine.pojo.BuildRetryInfo
 import com.tencent.devops.process.engine.pojo.LatestRunningBuild
 import com.tencent.devops.process.engine.pojo.PipelineBuildContainer
@@ -267,33 +268,35 @@ class PipelineRuntimeService @Autowired constructor(
         return pipelineBuildDao.countAllBuildWithStatus(dslContext, projectId, pipelineId, setOf(BuildStatus.RUNNING))
     }
 
-    /** 根据状态信息获取并发组构建列表
-     * @return Pair( PIPELINE_ID , BUILD_ID )
-     */
+    /** 根据状态信息获取并发组构建列表 */
     fun getBuildInfoListByConcurrencyGroup(
         projectId: String,
         concurrencyGroup: String,
-        status: List<BuildStatus>
-    ): List<Pair<String, String>> {
+        status: List<BuildStatus>,
+        excludeBuildId: String? = null
+    ): List<ConcurrencyGroupBuild> {
         return pipelineBuildDao.getBuildTasksByConcurrencyGroup(
             dslContext = dslContext,
             projectId = projectId,
             concurrencyGroup = concurrencyGroup,
-            statusSet = status
-        ).map { Pair(it.value1(), it.value2()) }
+            statusSet = status,
+            excludeBuildId = excludeBuildId
+        )
     }
 
     fun getBuildInfoListByConcurrencyGroupNull(
         projectId: String,
         pipelineId: String,
-        status: List<BuildStatus>
-    ): List<Pair<String, String>> {
+        status: List<BuildStatus>,
+        excludeBuildId: String? = null
+    ): List<ConcurrencyGroupBuild> {
         return pipelineBuildDao.getBuildTasksByConcurrencyGroupNull(
             dslContext = dslContext,
             projectId = projectId,
             pipelineId = pipelineId,
-            statusSet = status
-        ).map { Pair(it.value1(), it.value2()) }
+            statusSet = status,
+            excludeBuildId = excludeBuildId
+        )
     }
 
     fun getBuildNoByByPair(buildIds: Set<String>, projectId: String?): MutableMap<String, String> {

--- a/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/utils/ConcurrencyCancelGuardUtils.kt
+++ b/src/backend/ci/core/process/biz-base/src/main/kotlin/com/tencent/devops/process/engine/utils/ConcurrencyCancelGuardUtils.kt
@@ -1,0 +1,117 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 Tencent.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.devops.process.engine.utils
+
+import com.tencent.devops.process.engine.pojo.ConcurrencyGroupBuild
+import org.slf4j.LoggerFactory
+
+/**
+ * 并发组 cancel-in-progress 的当前构建上下文。
+ *
+ * @param retryBuildNum 仅重试时有值。为空表示新触发，只排除自己、不比较构建号。
+ */
+data class ConcurrencyCancelContext(
+    val pipelineId: String,
+    val buildId: String,
+    val retryBuildNum: Int? = null
+) {
+    companion object {
+        /**
+         * [currentBuildNum] 只在 [isRetry] 为 true 时求值，避免新触发多一次查库。
+         */
+        fun of(
+            pipelineId: String,
+            buildId: String,
+            isRetry: Boolean,
+            currentBuildNum: () -> Int?
+        ) = ConcurrencyCancelContext(
+            pipelineId = pipelineId,
+            buildId = buildId,
+            retryBuildNum = if (isRetry) currentBuildNum() else null
+        )
+    }
+}
+
+/**
+ * 并发组 cancel-in-progress 取消目标过滤，只做内存判定。
+ *
+ * #13450 重试会复用当前 buildId，查询未完成构建时可能把"自己"查出来误杀；
+ * 重试旧构建时也不能把同流水线中构建号更大的"最新构建"取消掉。
+ * 新触发（非重试）仍取消组内其他未完成构建，保持历史逻辑。
+ *
+ */
+object ConcurrencyCancelGuardUtils {
+
+    private val logger = LoggerFactory.getLogger(ConcurrencyCancelGuardUtils::class.java)
+
+    /**
+     * 从候选列表中去掉不应取消的构建，返回真正要 cancel 的目标。
+     * @param candidateBuilds 候选待取消的构建集合
+     * @param currentContext 当前触发/重试构建的上下文，包含构建号（仅重试时有值）等信息
+     * @return 过滤掉「不应取消」的构建后，最终需要执行 cancel 的目标列表
+     */
+    fun filterTargets(
+        candidateBuilds: Collection<ConcurrencyGroupBuild>,
+        currentContext: ConcurrencyCancelContext
+    ): List<ConcurrencyGroupBuild> {
+        return candidateBuilds.filterNot { candidate ->
+            val skip = shouldSkip(currentContext, candidate)
+            if (skip) {
+                logger.info(
+                    "[${candidate.pipelineId}]|[${candidate.buildId}]|skip concurrency cancel|" +
+                        "current=${currentContext.buildId}|retryBuildNum=${currentContext.retryBuildNum}"
+                )
+            }
+            skip
+        }
+    }
+
+    /**
+     * 判断是否应跳过取消。
+     * @param currentContext 当前触发/重试构建的上下文，包含构建号（仅重试时有值）等信息
+     * @param candidate 候选待取消的构建
+     * @return true 表示跳过取消（保留该构建），false 表示可以取消。
+     */
+    private fun shouldSkip(
+        currentContext: ConcurrencyCancelContext,
+        candidate: ConcurrencyGroupBuild
+    ): Boolean {
+        // 重试复用同一 buildId，绝不能把当前这次启动/重试取消掉
+        if (candidate.buildId == currentContext.buildId) {
+            return true
+        }
+        // 新触发：retryBuildNum 为空，组内其他未完成构建仍按历史逻辑取消
+        val currentNum = currentContext.retryBuildNum ?: return false
+        // 跨流水线并发组的 buildNum 彼此不可比，保持原有取消行为
+        if (candidate.pipelineId != currentContext.pipelineId) {
+            return false
+        }
+        // 同流水线重试：构建号更大的是更新的那次，不能误杀
+        return candidate.buildNum > currentNum
+    }
+}

--- a/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/utils/ConcurrencyCancelGuardUtilsTest.kt
+++ b/src/backend/ci/core/process/biz-base/src/test/kotlin/com/tencent/devops/process/engine/utils/ConcurrencyCancelGuardUtilsTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-CI 蓝鲸持续集成平台 available.
+ *
+ * Copyright (C) 2019 Tencent.  All rights reserved.
+ *
+ * BK-CI 蓝鲸持续集成平台 is licensed under the MIT license.
+ *
+ * A copy of the MIT License is included in this file.
+ *
+ *
+ * Terms of the MIT License:
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.tencent.devops.process.engine.utils
+
+import com.tencent.devops.process.engine.pojo.ConcurrencyGroupBuild
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ConcurrencyCancelGuardUtilsTest {
+
+    @Test
+    fun contextOnlyResolveBuildNumOnRetry() {
+        var loaded = false
+        val retryContext = ConcurrencyCancelContext.of(
+            pipelineId = "p-1",
+            buildId = "b-1",
+            isRetry = true
+        ) {
+            loaded = true
+            5
+        }
+        Assertions.assertEquals(5, retryContext.retryBuildNum)
+        Assertions.assertTrue(loaded)
+
+        loaded = false
+        val newStartContext = ConcurrencyCancelContext.of(
+            pipelineId = "p-1",
+            buildId = "b-new",
+            isRetry = false
+        ) {
+            loaded = true
+            1
+        }
+        Assertions.assertNull(newStartContext.retryBuildNum)
+        Assertions.assertFalse(loaded)
+    }
+
+    @Test
+    fun skipCancelSelfAlways() {
+        val current = ConcurrencyCancelContext("p-1", "b-self")
+        Assertions.assertTrue(
+            filter(current, listOf(build("p-1", "b-self", 1))).isEmpty()
+        )
+        val retryCurrent = ConcurrencyCancelContext("p-1", "b-self", retryBuildNum = 5)
+        Assertions.assertTrue(
+            filter(retryCurrent, listOf(build("p-1", "b-self", 8))).isEmpty()
+        )
+    }
+
+    @Test
+    fun newTriggerStillCancelOtherBuilds() {
+        val result = ConcurrencyCancelGuardUtils.filterTargets(
+            candidateBuilds = listOf(build("p-1", "b-old-running", 3)),
+            currentContext = ConcurrencyCancelContext("p-1", "b-new")
+        )
+        Assertions.assertEquals(listOf(build("p-1", "b-old-running", 3)), result)
+    }
+
+    @Test
+    fun retrySkipNewerSamePipelineBuild() {
+        val current = ConcurrencyCancelContext("p-1", "b-old", retryBuildNum = 5)
+        Assertions.assertTrue(
+            filter(current, listOf(build("p-1", "b-latest", 6))).isEmpty()
+        )
+    }
+
+    @Test
+    fun retryStillCancelOlderSamePipelineBuild() {
+        val current = ConcurrencyCancelContext("p-1", "b-latest", retryBuildNum = 6)
+        Assertions.assertEquals(
+            listOf(build("p-1", "b-old-running", 5)),
+            filter(current, listOf(build("p-1", "b-old-running", 5)))
+        )
+    }
+
+    @Test
+    fun retryKeepCrossPipelineCancel() {
+        val result = ConcurrencyCancelGuardUtils.filterTargets(
+            candidateBuilds = listOf(build("p-2", "b-p2", 99)),
+            currentContext = ConcurrencyCancelContext("p-1", "b-p1", retryBuildNum = 1)
+        )
+        Assertions.assertEquals(listOf(build("p-2", "b-p2", 99)), result)
+    }
+
+    private fun filter(
+        current: ConcurrencyCancelContext,
+        candidates: List<ConcurrencyGroupBuild>
+    ) = ConcurrencyCancelGuardUtils.filterTargets(candidates, current)
+
+    private fun build(pipelineId: String, buildId: String, buildNum: Int) =
+        ConcurrencyGroupBuild(pipelineId, buildId, buildNum)
+}

--- a/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildStartControl.kt
+++ b/src/backend/ci/core/process/biz-engine/src/main/kotlin/com/tencent/devops/process/engine/control/BuildStartControl.kt
@@ -71,6 +71,8 @@ import com.tencent.devops.process.engine.control.lock.BuildIdLock
 import com.tencent.devops.process.engine.control.lock.ConcurrencyGroupLock
 import com.tencent.devops.process.engine.control.lock.PipelineBuildNoLock
 import com.tencent.devops.process.engine.control.lock.PipelineBuildStartLock
+import com.tencent.devops.process.engine.utils.ConcurrencyCancelContext
+import com.tencent.devops.process.engine.utils.ConcurrencyCancelGuardUtils
 import com.tencent.devops.process.engine.pojo.BuildInfo
 import com.tencent.devops.process.engine.pojo.LatestRunningBuild
 import com.tencent.devops.process.engine.pojo.event.PipelineBuildCancelEvent
@@ -342,10 +344,12 @@ class BuildStartControl @Autowired constructor(
                 )?.buildId == buildId
             }
             // #6521 并发组中需要等待其他流水线
+            // #13450 排除当前 buildId，避免重试时把自己查成 RUNNING 后误取消
             val concurrencyGroupRunning = pipelineRuntimeService.getBuildInfoListByConcurrencyGroup(
                 projectId = projectId,
                 concurrencyGroup = concurrencyGroup,
-                status = listOf(BuildStatus.RUNNING)
+                status = listOf(BuildStatus.RUNNING),
+                excludeBuildId = buildId
             ).toMutableList()
 
             // #8143 兼容旧流水线版本 TODO 待模板设置补上漏洞，后期下掉 #8143
@@ -355,7 +359,8 @@ class BuildStartControl @Autowired constructor(
                     pipelineRuntimeService.getBuildInfoListByConcurrencyGroupNull(
                         projectId = projectId,
                         pipelineId = pipelineId,
-                        status = listOf(BuildStatus.RUNNING)
+                        status = listOf(BuildStatus.RUNNING),
+                        excludeBuildId = buildId
                     )
                 )
             }
@@ -382,11 +387,19 @@ class BuildStartControl @Autowired constructor(
                         stageId = null,
                         needShortUrl = false
                     )
-                    concurrencyGroupRunning.forEach { (pipelineId, buildId) ->
-                        pipelineRuntimeService.concurrencyCancelBuildPipeline(
-                            projectId = projectId,
+                    val cancelTargets = ConcurrencyCancelGuardUtils.filterTargets(
+                        candidateBuilds = concurrencyGroupRunning,
+                        currentContext = ConcurrencyCancelContext.of(
                             pipelineId = pipelineId,
                             buildId = buildId,
+                            isRetry = buildInfo.executeCount > 1
+                        ) { buildInfo.buildNum }
+                    )
+                    cancelTargets.forEach { target ->
+                        pipelineRuntimeService.concurrencyCancelBuildPipeline(
+                            projectId = projectId,
+                            pipelineId = target.pipelineId,
+                            buildId = target.buildId,
                             userId = buildInfo.startUser,
                             groupName = concurrencyGroup,
                             detailUrl = detailUrl
@@ -395,8 +408,8 @@ class BuildStartControl @Autowired constructor(
                 }
                 val detailUrl = pipelineUrlBean.genBuildDetailUrl(
                     projectCode = projectId,
-                    pipelineId = concurrencyGroupRunning.first().first,
-                    buildId = concurrencyGroupRunning.first().second,
+                    pipelineId = concurrencyGroupRunning.first().pipelineId,
+                    buildId = concurrencyGroupRunning.first().buildId,
                     position = null,
                     stageId = null,
                     needShortUrl = false
@@ -407,7 +420,7 @@ class BuildStartControl @Autowired constructor(
                         params = arrayOf(
                             setting.runLockType.name, concurrencyGroup,
                             concurrencyGroupRunning.count().toString(),
-                            "<a target='_blank' href='$detailUrl'>${concurrencyGroupRunning.first().second}</a>"
+                            "<a target='_blank' href='$detailUrl'>${concurrencyGroupRunning.first().buildId}</a>"
                         )
                     ),
                     buildId = buildId, tag = TAG, containerHashId = JOB_ID, executeCount = executeCount,

--- a/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/builds/PipelineBuildFacadeService.kt
+++ b/src/backend/ci/core/process/biz-process/src/main/kotlin/com/tencent/devops/process/service/builds/PipelineBuildFacadeService.kt
@@ -2012,7 +2012,7 @@ class PipelineBuildFacadeService(
             projectId = projectId,
             concurrencyGroup = buildHistory.concurrencyGroup!!,
             status = listOf(BuildStatus.QUEUE, BuildStatus.QUEUE_CACHE)
-        ).indexOfFirst { it.second == buildHistory.id } + 1
+        ).indexOfFirst { it.buildId == buildHistory.id } + 1
     } else {
         pipelineRuntimeService.getTotalBuildHistoryCount(
             projectId = projectId,


### PR DESCRIPTION
bug: 当流水线配置了同一时间只允许一条流水线跑（取消正在运行的构建）时，重试时可能误把最新的构建取消掉 #13450