### PR TITLE
fix: request-selector 支持搜索 URL 变量替换

### DIFF
--- a/src/frontend/devops-pipeline/src/components/atomFormField/RequestSelector/index.vue
+++ b/src/frontend/devops-pipeline/src/components/atomFormField/RequestSelector/index.vue
@@ -263,7 +263,26 @@
                     this.timeId = setTimeout(async () => {
                         try {
                             const regExp = new RegExp(this.replaceKey, 'g')
-                            const url = this.searchUrl.replace(regExp, name)
+                            let searchContextKey = '__requestSelectorSearch__'
+                            while (this.searchUrl.includes(searchContextKey)) {
+                                searchContextKey += '_'
+                            }
+                            const searchUrl = this.searchUrl
+                                .replace(regExp, `{${searchContextKey}}`)
+                                .replace(/\\/g, '\\\\')
+                                .replace(/'/g, "\\'")
+                                .replace(/\r/g, '\\r')
+                                .replace(/\n/g, '\\n')
+                                .replace(/\u2028/g, '\\u2028')
+                                .replace(/\u2029/g, '\\u2029')
+                            const query = this.$route.params
+                            const url = this.urlParse(searchUrl, {
+                                bkPoolType: this?.container?.dispatchType?.buildType,
+                                ...query,
+                                ...(this.paramValues || {}),
+                                ...this.element,
+                                [searchContextKey]: name
+                            })
                             const data = await this.$ajax.get(url)
                             const resData = this.getResponseData(data)
 


### PR DESCRIPTION
## 变更内容

- 让 `request-selector` 的远程搜索 URL 复用现有变量解析逻辑，支持 `{projectId}` 等上下文变量替换。
- 保留 `replaceKey` 搜索词替换行为，并避免固定单引号、反斜杠或特殊搜索词影响 URL 解析。
- 改动仅限 `devops-pipeline` 的 `RequestSelector.handleRemoteSearch`。

## 验证

- 目标文件 ESLint 检查通过。
- `devops-pipeline` 本地编译通过。
- 浏览器验证变量替换、正常结果、空态及特殊字符搜索场景通过。

Fixes #13614
